### PR TITLE
Sort default ends with heap sort

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
     "license": "GPL-3.0-only",
     "devDependencies": {
         "prettier": "^2.4.0",
-        "prettier-plugin-solidity": "^1.0.0-beta.18",
-        "solhint": "^3.3.6",
+        "prettier-plugin-solidity": "https://github.com/prettier-solidity/prettier-plugin-solidity.git#fc77fd6eff0c232d84ff50a147592a94b62e03d7",
+        "solhint": "^3.3.7",
         "solhint-plugin-prettier": "^0.0.5"
+    },
+    "resolutions": {
+        "solhint/@solidity-parser/parser": "0.14.2-beta.1"
     },
     "scripts": {
         "lint": "solhint --max-warnings=0 'src/**/*.sol'",

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -414,7 +414,7 @@ contract DripsHub is Managed {
     /// @param userId The user ID
     /// @param receivers The list of the user's splits receivers to be set.
     /// Must be sorted by the splits receivers' addresses, deduplicated and without 0 weights.
-    /// Each splits receiver will be getting `weight / TOTAL_SPLITS_WEIGHT`
+    /// Each splits receiver will be getting `weight / totalSplitsWeight`
     /// share of the funds collected by the user.
     function setSplits(uint256 userId, SplitsReceiver[] memory receivers)
         public

--- a/src/test/DefaultEndsHeap.t.sol
+++ b/src/test/DefaultEndsHeap.t.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.13;
+
+import {DSTest} from "ds-test/test.sol";
+import {DefaultEndsHeap} from "../Drips.sol";
+import {RandomUtils} from "./RandomUtils.t.sol";
+
+using DefaultEndsHeap for uint256[];
+
+contract DefaultEndsHeapTest is DSTest, RandomUtils {
+    struct DefaultEnd {
+        uint32 start;
+        uint128 amtPerSec;
+    }
+
+    mapping(uint32 => uint256) internal amtPerSecs;
+
+    function runTest(DefaultEnd[] memory input) internal {
+        // Prepare the list of default ends
+        uint256[] memory defaultEnds = new uint256[](input.length);
+        uint256 length = 0;
+        uint256 totalAmtPerSec = 0;
+        uint256 gasUsed = 0;
+
+        // Fill up the list of default ends
+        for (uint256 i = 0; i < input.length; i++) {
+            uint32 start = input[i].start;
+            uint128 amtPerSec = input[i].amtPerSec;
+            gasUsed += gasleft();
+            defaultEnds.push(length++, start, amtPerSec);
+            gasUsed -= gasleft();
+            totalAmtPerSec += amtPerSec;
+            amtPerSecs[start] += amtPerSec;
+        }
+
+        // Build the heap
+        gasUsed += gasleft();
+        defaultEnds.heapify(length);
+        gasUsed -= gasleft();
+
+        // Drain the heap
+        uint32 prevStart;
+        bool prevStartSet = false;
+        while (length > 0) {
+            gasUsed += gasleft();
+            uint32 start = defaultEnds.peekStart();
+            gasUsed -= gasleft();
+            if (prevStartSet) assertLt(prevStart, start, "Starts not sorted");
+            prevStart = start;
+            prevStartSet = true;
+            uint136 amtPerSec;
+            gasUsed += gasleft();
+            (length, amtPerSec) = defaultEnds.popAmtPerSec(length);
+            gasUsed -= gasleft();
+            assertEq(amtPerSec, amtPerSecs[start], "Invalid amtPerSec");
+            amtPerSecs[start] = 0;
+            totalAmtPerSec -= amtPerSec;
+        }
+        assertEq(totalAmtPerSec, 0, "Some amtPerSecs skipped");
+        // To print the results run tests with DappTools parameter `--verbose 2`
+        emit log_named_uint("Gas used", gasUsed);
+    }
+
+    function generateRandomInput(uint256 length) internal returns (DefaultEnd[] memory input) {
+        input = new DefaultEnd[](length);
+        for (uint256 i = 0; i < length; i++) {
+            input[i].start = randomUint32();
+            input[i].amtPerSec = randomUint128();
+        }
+    }
+
+    function generateSortedInput(uint256 length) internal returns (DefaultEnd[] memory input) {
+        input = new DefaultEnd[](length);
+        for (uint32 i = 0; i < length; i++) {
+            input[i].start = i;
+            input[i].amtPerSec = randomUint128();
+        }
+    }
+
+    function generateRevSortedInput(uint256 length) internal returns (DefaultEnd[] memory input) {
+        input = new DefaultEnd[](length);
+        for (uint256 i = 0; i < length; i++) {
+            input[i].start = uint32(length - i);
+            input[i].amtPerSec = randomUint128();
+        }
+    }
+
+    function generateConstantInput(uint256 length) internal returns (DefaultEnd[] memory input) {
+        input = new DefaultEnd[](length);
+        for (uint256 i = 0; i < length; i++) {
+            input[i].start = 1;
+            input[i].amtPerSec = randomUint128();
+        }
+    }
+
+    function testEmpty() public {
+        DefaultEnd[] memory input = new DefaultEnd[](0);
+        runTest(input);
+    }
+
+    function testSingle() public {
+        DefaultEnd[] memory input = new DefaultEnd[](1);
+        input[0] = DefaultEnd(1, 2);
+        runTest(input);
+    }
+
+    function testFullLayerMinusOne() public {
+        setSeed(bytes32(uint256(1)));
+        runTest(generateRandomInput(2));
+    }
+
+    function testFullLayer() public {
+        setSeed(bytes32(uint256(1)));
+        runTest(generateRandomInput(3));
+    }
+
+    function testFullLayerPlusOne() public {
+        setSeed(bytes32(uint256(1)));
+        runTest(generateRandomInput(4));
+    }
+
+    function testOverflowingAmtPerSec() public {
+        DefaultEnd[] memory input = new DefaultEnd[](2);
+        input[0] = DefaultEnd(1, type(uint128).max);
+        input[0] = DefaultEnd(2, 1);
+        runTest(input);
+    }
+
+    function testFuzzySize(bytes32 seed) public {
+        setSeed(seed);
+        runTest(generateRandomInput(random(100)));
+    }
+
+    function test10Random() public {
+        setSeed(bytes32(uint256(1)));
+        runTest(generateRandomInput(10));
+    }
+
+    function test100Random() public {
+        setSeed(bytes32(uint256(1)));
+        runTest(generateRandomInput(100));
+    }
+
+    function test10Sorted() public {
+        setSeed(bytes32(uint256(1)));
+        runTest(generateSortedInput(10));
+    }
+
+    function test100Sorted() public {
+        setSeed(bytes32(uint256(1)));
+        runTest(generateSortedInput(100));
+    }
+
+    function test10RevSorted() public {
+        setSeed(bytes32(uint256(1)));
+        runTest(generateRevSortedInput(10));
+    }
+
+    function test100RevSorted() public {
+        setSeed(bytes32(uint256(1)));
+        runTest(generateRevSortedInput(100));
+    }
+
+    function test10ConstantInput() public {
+        setSeed(bytes32(uint256(1)));
+        runTest(generateConstantInput(10));
+    }
+
+    function test100ConstantInput() public {
+        setSeed(bytes32(uint256(1)));
+        runTest(generateConstantInput(100));
+    }
+}

--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -4,26 +4,9 @@ pragma solidity ^0.8.13;
 import {DSTest} from "ds-test/test.sol";
 import {Hevm} from "./Hevm.t.sol";
 import {Drips, DripsReceiver} from "../Drips.sol";
+import {RandomUtils} from "./RandomUtils.t.sol";
 
-contract PseudoRandomUtils {
-    bytes32 private salt;
-    bool private initialized = false;
-
-    // returns a pseudo-random number between 0 and range
-    function random(uint256 range) public returns (uint256) {
-        require(initialized, "salt not set for test run");
-        salt = keccak256(bytes.concat(salt));
-        return uint256(salt) % range;
-    }
-
-    function initSalt(bytes32 salt_) public {
-        require(initialized == false, "only init salt once per test run");
-        salt = salt_;
-        initialized = true;
-    }
-}
-
-contract DripsTest is DSTest, PseudoRandomUtils {
+contract DripsTest is DSTest, RandomUtils {
     string internal constant ERROR_NOT_SORTED = "Receivers not sorted";
     string internal constant ERROR_INVALID_DRIPS_LIST = "Invalid current drips list";
     string internal constant ERROR_BALANCE = "Insufficient balance";
@@ -887,8 +870,8 @@ contract DripsTest is DSTest, PseudoRandomUtils {
         receiveDrips(otherAsset, receiver2, 0);
     }
 
-    function testFuzzDripsReceiver(bytes32 salt) public {
-        initSalt(salt);
+    function testFuzzDripsReceiver(bytes32 seed) public {
+        setSeed(seed);
         uint8 amountReceivers = 10;
         uint128 maxAmtPerSec = 50;
         uint32 maxDuration = 100;

--- a/src/test/RandomUtils.t.sol
+++ b/src/test/RandomUtils.t.sol
@@ -21,4 +21,20 @@ contract RandomUtils {
         seed = keccak256(bytes.concat(seed));
         return uint256(seed);
     }
+
+    function randomUint128(uint128 maxValue) public returns (uint128) {
+        return uint128(random(maxValue));
+    }
+
+    function randomUint128() public returns (uint128) {
+        return randomUint128(type(uint128).max);
+    }
+
+    function randomUint32(uint32 range) public returns (uint32) {
+        return uint32(random(range));
+    }
+
+    function randomUint32() public returns (uint32) {
+        return randomUint32(type(uint32).max);
+    }
 }

--- a/src/test/RandomUtils.t.sol
+++ b/src/test/RandomUtils.t.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.13;
+
+contract RandomUtils {
+    bytes32 private seed;
+    bool private initialized = false;
+
+    function setSeed(bytes32 seed_) public {
+        require(!initialized, "only init seed once per test run");
+        seed = seed_;
+        initialized = true;
+    }
+
+    function random(uint256 maxValue) public returns (uint256 value) {
+        value = random();
+        if (maxValue != type(uint256).max) value %= maxValue + 1;
+    }
+
+    function random() public returns (uint256 value) {
+        require(initialized, "seed not set for test run");
+        seed = keccak256(bytes.concat(seed));
+        return uint256(seed);
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@solidity-parser/parser@^0.13.2":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.13.2.tgz#b6c71d8ca0b382d90a7bbed241f9bc110af65cbe"
-  integrity sha512-RwHnpRnfrnD2MSPveYoPh8nhofEvX7fgjHk1Oq+NNvCcLx4r1js91CO9o+F/F3fBzOCyvm8kKRTriFICX/odWw==
+"@solidity-parser/parser@0.14.2-beta.1", "@solidity-parser/parser@^0.14.1", "@solidity-parser/parser@^0.14.2-beta.1":
+  version "0.14.2-beta.1"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.2-beta.1.tgz#114dc7ff21b913b5eaf80a85123a77a5d53e22e1"
+  integrity sha512-UU/LD1nG4XjZ4D9FxpjHeG5/i5MXc3CwJHIvLRI90sn+Ij9cGSyq9sBnSLGAubyhYULnH4/lB3pcbkXB9iO3MA==
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
 
@@ -65,7 +65,7 @@ ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
-ansi-regex@^5.0.0:
+ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -229,6 +229,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+emoji-regex@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.1.0.tgz#d50e383743c0f7a5945c47087295afc112e3cf66"
+  integrity sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -238,11 +243,6 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-emoji-regex@^9.2.2:
-  version "9.2.2"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
-  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -710,17 +710,16 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier-plugin-solidity@^1.0.0-beta.18:
-  version "1.0.0-beta.18"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.18.tgz#9705453bacd55b3242110d472f23f624ae6777fc"
-  integrity sha512-ezWdsG/jIeClmYBzg8V9Voy8jujt+VxWF8OS3Vld+C3c+3cPVib8D9l8ahTod7O5Df1anK9zo+WiiS5wb1mLmg==
+"prettier-plugin-solidity@https://github.com/prettier-solidity/prettier-plugin-solidity.git#fc77fd6eff0c232d84ff50a147592a94b62e03d7":
+  version "1.0.0-beta.19"
+  resolved "https://github.com/prettier-solidity/prettier-plugin-solidity.git#fc77fd6eff0c232d84ff50a147592a94b62e03d7"
   dependencies:
-    "@solidity-parser/parser" "^0.13.2"
-    emoji-regex "^9.2.2"
+    "@solidity-parser/parser" "^0.14.2-beta.1"
+    emoji-regex "^10.1.0"
     escape-string-regexp "^4.0.0"
-    semver "^7.3.5"
+    semver "^7.3.7"
     solidity-comments-extractor "^0.0.7"
-    string-width "^4.2.2"
+    string-width "^4.2.3"
 
 prettier@^1.14.3:
   version "1.19.1"
@@ -799,10 +798,10 @@ semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.5:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -839,12 +838,12 @@ solhint-plugin-prettier@^0.0.5:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-solhint@^3.3.6:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/solhint/-/solhint-3.3.6.tgz#abe9af185a9a7defefba480047b3e42cbe9a1210"
-  integrity sha512-HWUxTAv2h7hx3s3hAab3ifnlwb02ZWhwFU/wSudUHqteMS3ll9c+m1FlGn9V8ztE2rf3Z82fQZA005Wv7KpcFA==
+solhint@^3.3.7:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/solhint/-/solhint-3.3.7.tgz#b5da4fedf7a0fee954cb613b6c55a5a2b0063aa7"
+  integrity sha512-NjjjVmXI3ehKkb3aNtRJWw55SUVJ8HMKKodwe0HnejA+k0d2kmhw7jvpa+MCTbcEgt8IWSwx0Hu6aCo/iYOZzQ==
   dependencies:
-    "@solidity-parser/parser" "^0.13.2"
+    "@solidity-parser/parser" "^0.14.1"
     ajv "^6.6.1"
     antlr4 "4.7.1"
     ast-parents "0.0.1"
@@ -888,14 +887,14 @@ string-width@^3.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
-  integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.0"
+    strip-ansi "^6.0.1"
 
 strip-ansi@^4.0.0:
   version "4.0.0"
@@ -911,12 +910,12 @@ strip-ansi@^5.1.0:
   dependencies:
     ansi-regex "^4.1.0"
 
-strip-ansi@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
-  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
-    ansi-regex "^5.0.0"
+    ansi-regex "^5.0.1"
 
 strip-json-comments@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Replaces insert sort with heap sort when calculating the default drips end time.

For the extreme case of 100 random items the cost of sorting itself is cut from ~1,680,000 gas to ~229,000 gas.

I wonder if we need some benchmarking tests to prevent future regressions and how should we organize them?

The representation of a default end is changed from a structure with 2 fields to a packed uint256 to reduce gas. Unfortunately a user defined type did introduce some overhead despite being a theoretically zero-cost abstraction.