### PR TITLE
feat: calc defaultEnd based on unsorted array

### DIFF
--- a/src/Drips.sol
+++ b/src/Drips.sol
@@ -354,7 +354,7 @@ library Drips {
         // defaultEnd =(balance + a_1*s_1 + ... + a_n*s_n)/(a_1 + ... a_n)
         uint136 defaultEnd = uint136((balance + defaultSum) / defaultDivisor);
         if (defaultEnd > type(uint32).max) defaultEnd = type(uint32).max;
-        require(defaultEnd >= defaultsHighestStart, "Run out of funds before default drips start");
+        require(defaultEnd > defaultsHighestStart, "Run out of funds before default drips start");
         return uint32(defaultEnd);
     }
 

--- a/src/Drips.sol
+++ b/src/Drips.sol
@@ -336,8 +336,8 @@ library Drips {
             (uint32 start, uint32 end) = _dripsRangeInFuture(receiver, _currTimestamp(), 0);
             if (start > highest) highest = start;
             if (receiver.duration == 0) {
-                defaultSum += uint256(uint256(receiver.amtPerSec) * start);
-                defaultDivisor += uint256(receiver.amtPerSec);
+                defaultSum += uint256(receiver.amtPerSec) * start;
+                defaultDivisor += receiver.amtPerSec;
             } else {
                 uint192 spent = (end - start) * receiver.amtPerSec;
                 require(balance >= spent, "Insufficient balance");

--- a/src/Drips.sol
+++ b/src/Drips.sol
@@ -325,7 +325,7 @@ library Drips {
         uint256 defaultSum = 0;
         uint256 defaultDivisor = 0;
         // highest seen start date
-        uint32 highest = 0;
+        uint32 defaultsHighestStart = 0;
 
         for (uint256 i = 0; i < receivers.length; i++) {
             DripsReceiver memory receiver = receivers[i];
@@ -334,8 +334,8 @@ library Drips {
             // Default drips end doesn't matter here, the end time is ignored when
             // the duration is zero and if it's non-zero the default end is not used anyway
             (uint32 start, uint32 end) = _dripsRangeInFuture(receiver, _currTimestamp(), 0);
-            if (start > highest) highest = start;
             if (receiver.duration == 0) {
+                if (start > defaultsHighestStart) defaultsHighestStart = start;
                 defaultSum += uint256(receiver.amtPerSec) * start;
                 defaultDivisor += receiver.amtPerSec;
             } else {
@@ -354,7 +354,7 @@ library Drips {
         // defaultEnd =(balance + a_1*s_1 + ... + a_n*s_n)/(a_1 + ... a_n)
         uint136 defaultEnd = uint136((balance + defaultSum) / defaultDivisor);
         if (defaultEnd > type(uint32).max) defaultEnd = type(uint32).max;
-        require(defaultEnd >= highest, "Run out of funds before default drips start");
+        require(defaultEnd >= defaultsHighestStart, "Run out of funds before default drips start");
         return uint32(defaultEnd);
     }
 

--- a/src/Drips.sol
+++ b/src/Drips.sol
@@ -280,7 +280,7 @@ library Drips {
             newBalance = uint128(uint136(balance));
             realBalanceDelta = int128(balance - int128(currBalance));
         }
-        uint32 newDefaultEnd = _defaultEnd(newBalance, newReceivers);
+        uint32 newDefaultEnd = calcDefaultEnd(newBalance, newReceivers);
         _updateReceiverStates(
             s.dripsStates[assetId],
             cycleSecs,
@@ -315,7 +315,7 @@ library Drips {
     /// @param receivers The list of drips receivers.
     /// Must be sorted, deduplicated and without 0 amtPerSecs.
     /// @return defaultEndTime The end time of drips without duration.
-    function _defaultEnd(uint128 balance, DripsReceiver[] memory receivers)
+    function calcDefaultEnd(uint128 balance, DripsReceiver[] memory receivers)
         internal
         view
         returns (uint32 defaultEndTime)

--- a/src/Drips.sol
+++ b/src/Drips.sol
@@ -372,35 +372,19 @@ library Drips {
         uint256 sum = 0;
         uint256 divisor = 0;
 
-        // index of of the highest seen start date
-        uint8 highest = 0;
+        // highest seen start date
+        uint32 highest = 0;
 
         // default end time
         uint136 end;
         for (uint8 i = 0; i < length; i++) {
-            if (d[i].start > d[highest].start) highest = i;
+            if (d[i].start > highest) highest = d[i].start;
             sum += uint256(d[i].amtPerSec * d[i].start);
             divisor += uint256(d[i].amtPerSec);
-
-            end = uint136((balance + sum) / divisor);
-            // not enough funds to cover all default drips
-            if (end < d[highest].start) {
-                // remove current element from sum, divisor and end
-                sum -= uint256(d[highest].amtPerSec * d[highest].start);
-                divisor -= d[highest].amtPerSec;
-                end = uint136((balance + sum) / divisor);
-
-                // set to zero that it is not the highest anymore
-                d[highest].start = 0;
-                // find previous highest
-                highest = 0;
-                for (uint8 j = 0; j < i; j++) {
-                    if (d[j].start > d[highest].start) highest = j;
-                }
-            }
         }
-
+        end = uint136((balance + sum) / divisor);
         if (end > type(uint32).max) end = type(uint32).max;
+        require(end >= highest, "Run out of funds before default drips start");
         return uint32(end);
     }
 

--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import {DSTest} from "ds-test/test.sol";
 import {Hevm} from "./Hevm.t.sol";
-import {Drips, DripsReceiver} from "../Drips.sol";
+import {Drips, DripsReceiver, DefaultEnd} from "../Drips.sol";
 
 contract PseudoRandomUtils {
     bytes32 private salt;
@@ -1021,5 +1021,37 @@ contract DripsTest is DSTest, PseudoRandomUtils {
             probStartNow
         );
         setDrips(sender, 0, maxCosts, receivers);
+    }
+    function testReceiverDefaultEndExampleA() public {
+        DefaultEnd[] memory defaults = new DefaultEnd[](2);
+        defaults[0] = DefaultEnd(50, 1);
+        defaults[1] = DefaultEnd(0, 1);
+
+        uint32 endtime = Drips._receiversDefaultEnd(defaults, 2, 100);
+        assertEq(endtime, 75);
+    }
+
+    function testReceiverDefaultEndExampleB() public {
+        DefaultEnd[] memory defaults = new DefaultEnd[](2);
+        defaults[0] = DefaultEnd(100, 2);
+        defaults[1] = DefaultEnd(120, 4);
+
+        uint32 endtime = Drips._receiversDefaultEnd(defaults, 2, 100);
+        assertEq(endtime, 130);
+    }
+
+    function testReceiverDefaultEndNotEnoughToCoverAll() public {
+        uint8 length = 4;
+        DefaultEnd[] memory defaults = new DefaultEnd[](length);
+        defaults[0] = DefaultEnd(50, 1);
+
+        // not enough to cover this two
+        defaults[1] = DefaultEnd(170, 1);
+        defaults[2] = DefaultEnd(150, 4);
+
+        defaults[3] = DefaultEnd(0, 1);
+
+        uint32 endtime = Drips._receiversDefaultEnd(defaults, length, 100);
+        assertEq(endtime, 75);
     }
 }

--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -55,7 +55,7 @@ contract DripsTest is DSTest, PseudoRandomUtils {
     }
 
     function warpBy(uint256 secs) internal {
-        Hevm(HEVM_ADDRESS).warp(block.timestamp + secs);
+        warpTo(block.timestamp + secs);
     }
 
     function warpTo(uint256 timestamp) internal {

--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -790,7 +790,7 @@ contract DripsTest is DSTest, PseudoRandomUtils {
         for (uint160 i = 0; i < countMax; i++) {
             receivers[i] = recv(i, 1, 0, 0)[0];
         }
-        setDrips(sender, 0, 1 ether, receivers);
+        setDrips(sender, 0, uint128(countMax), receivers);
         receivers = recv(receivers, recv(countMax, 1, 0, 0));
         assertSetDripsReverts(
             sender,

--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -762,6 +762,10 @@ contract DripsTest is DSTest, PseudoRandomUtils {
         receiveDrips(receiver2, 55);
     }
 
+    function testDefaultEndSmallerThenScheduledDripStart() public {
+        setDrips(sender, 0, 120, recv(recv(receiver1, 1), recv(receiver2, 1, 100, 100)));
+    }
+
     function testLimitsTheTotalReceiversCount() public {
         uint160 countMax = Drips.MAX_DRIPS_RECEIVERS;
         DripsReceiver[] memory receivers = new DripsReceiver[](countMax);

--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -298,7 +298,11 @@ contract DripsTest is DSTest, PseudoRandomUtils {
         uint128 balanceFrom,
         uint128 balanceTo
     ) internal {
-        setDrips(userId, balanceFrom, balanceTo, loadCurrReceivers(defaultAsset, userId));
+        DripsReceiver[] memory receivers = recv();
+        if (balanceTo != 0) {
+           receivers = loadCurrReceivers(defaultAsset, userId);
+        }
+        setDrips(userId, balanceFrom, balanceTo, receivers);
     }
 
     function assertSetDripsReverts(

--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -774,7 +774,7 @@ contract DripsTest is DSTest, PseudoRandomUtils {
         }
         setDrips(sender, 0, 1 ether, receivers);
         receivers = recv(receivers, recv(countMax, 1, 0, 0));
-        assertSetDripsReverts(sender, 1 ether, 1 ether, receivers, "Too many drips receivers");
+        assertSetDripsReverts(sender, countMax, countMax + 1, receivers, "Too many drips receivers");
     }
 
     function testRejectsZeroAmtPerSecReceivers() public {

--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -1040,7 +1040,7 @@ contract DripsTest is DSTest, PseudoRandomUtils {
         view
         returns (uint32 end)
     {
-        return Drips._defaultEnd(balance, list);
+        return Drips.calcDefaultEnd(balance, list);
     }
 
     function testReceiverDefaultEndExampleA() public {
@@ -1050,7 +1050,7 @@ contract DripsTest is DSTest, PseudoRandomUtils {
         );
 
         warpTo(0);
-        uint32 endtime = Drips._defaultEnd(100, receivers);
+        uint32 endtime = Drips.calcDefaultEnd(100, receivers);
         assertEq(endtime, 75);
     }
 
@@ -1062,7 +1062,7 @@ contract DripsTest is DSTest, PseudoRandomUtils {
 
         // in the past
         Hevm(HEVM_ADDRESS).warp(70);
-        uint32 endtime = Drips._defaultEnd(100, receivers);
+        uint32 endtime = Drips.calcDefaultEnd(100, receivers);
         assertEq(endtime, 130);
     }
 

--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -588,7 +588,7 @@ contract DripsTest is DSTest, PseudoRandomUtils {
         receiveDrips(receiver, 0);
     }
 
-    function testDripsWithStartAfterFundsRunOut() public {
+    function testRejectsDripsWithStartAfterFundsRunOut() public {
         try
             this.setDripsExternal(
                 defaultAsset,

--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -134,6 +134,19 @@ contract DripsTest is DSTest, PseudoRandomUtils {
         uint256 inPercent = 100;
         uint256 probDefaultEnd = random(inPercent);
         uint256 probStartNow = random(inPercent);
+        return genRandomRecv(amountReceiver, maxAmtPerSec, maxStart, maxDuration, probDefaultEnd, probStartNow);
+    
+    }
+
+    function genRandomRecv(
+        uint8 amountReceiver,
+        uint128 maxAmtPerSec,
+        uint32 maxStart,
+        uint32 maxDuration,
+        uint256 probDefaultEnd,
+        uint256 probStartNow
+    ) internal returns (DripsReceiver[] memory) {
+        uint256 inPercent = 100;
         DripsReceiver[] memory receivers = new DripsReceiver[](amountReceiver);
         for (uint8 i = 0; i < amountReceiver; i++) {
             uint256 amtPerSec = random(maxAmtPerSec) + 1;
@@ -986,5 +999,27 @@ contract DripsTest is DSTest, PseudoRandomUtils {
         warpToCycleEnd();
         emit log_named_uint("receiveDrips.time", block.timestamp);
         receiveDrips(receivers, defaultEnd, updateTime);
+    }
+
+    function testBenchmarkReceivers() public {
+        initSalt("42");
+        uint8 amountReceivers = 100;
+        uint128 maxAmtPerSec = 50;
+        uint32 maxDuration = 100;
+        uint32 maxStart = 100;
+        // percent
+        uint256 probDefaultEnd = 100;
+        uint256 probStartNow = 20;
+
+        uint128 maxCosts = amountReceivers * maxAmtPerSec * maxDuration;
+        DripsReceiver[] memory receivers = genRandomRecv(
+            amountReceivers,
+            maxAmtPerSec,
+            maxStart,
+            maxDuration,
+            probDefaultEnd,
+            probStartNow
+        );
+        setDrips(sender, 0, maxCosts, receivers);
     }
 }

--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -1095,22 +1095,4 @@ contract DripsTest is DSTest, PseudoRandomUtils {
             assertEq(reason, ERROR_NOT_ENOUGH_FOR_DEFAULT_DRIPS, "Invalid set drips revert reason");
         }
     }
-
-    // function testReceiverDefaultEndNotEnoughToCoverAll() public {
-    //     uint8 length = 4;
-    //     DefaultEnd[] memory defaults = new DefaultEnd[](length);
-    //     defaults[0] = DefaultEnd(50, 1);
-
-    //     // not enough to cover this two
-    //     defaults[1] = DefaultEnd(170, 1);
-    //     defaults[2] = DefaultEnd(150, 4);
-
-    //     defaults[3] = DefaultEnd(0, 1);
-
-    //     try this.externalReceiverDefaultEnd(defaults, length, 100) {
-    //         assertTrue(false, "Set drips hasn't reverted");
-    //     } catch Error(string memory reason) {
-    //         assertEq(reason, ERROR_NOT_ENOUGH_FOR_DEFAULT_DRIPS, "Invalid set drips revert reason");
-    //     }
-    // }
 }


### PR DESCRIPTION
This PR contains a new approach for calculating the `defaultEnd` based on an unsorted array.

All existing tests are passing and I added a couple more.

However, there might be still some edge cases the new approach doesn't cover.

We move the discussion into this PR.

### Problem Description
A drip can be optional streamed until a user runs out of funds. These drips are called `defaultDrips`.
They are defined by a start time and an `amtPerSec`.  The `duration=0` indicates the defaultEnd.

After our implementation covers all normally scheduled drips (with a start and duration) we end up with a  leftover `balance` and an array of these defaultDrips.

The leftover balance can be used for defaultDrips.

We need to calculate based on the start dates and amtPerSec the block.timestamp when the user leftover balance will equal zero. 

This timestamp is the point in the time, when all defaultDrips will run out of funds.

**Example**
```
Balance=100
DripA: start: 100, amtPerSec=2
DripB: start: 120, amtPerSec=4

Here the defaultEnd will be 130. From timestamp 100 to 120 we drip 20*2 = 40.
Afterward the second one starts and we have a total amtPerSec 6. 120 to 130 we drip 10*6 = 60;

At timestamp 130 the entire balance has been spent.

100                 120         130
|--------------------|----------|
      amt=2           amt=2+4
```

### Current Algorithm
The current approach is to first sort the default drips array. The algorithm then looks at the time difference between two drip start dates step by step and calculates the amount spend during this time period. The totalAmtPerSec is increased afterwards with a new amtPerSec.

In each step, a temporary end time is calculated based on the currently seen default drips if they can be covered until the next drip.

In the example from above, the duration between the first two drips is 20 with a amtPerSec=2.

However, this approach requires as to first sorting the array which is expensive. 

### New Design
It is not required to sort the array in the first place. The entire problem can be seen as an equation. Which describes when the spend drips amount will be equal to the balance.

```
x... defaultEnd
s... start
a... amount
b... balance
```
**Entire Balance Spend Equation**
Example for only two default drips

$$
a_1(x-s_1) + a_2(x-s_2) = b
$$

The duration of a default drip can be described as `defaultEnd-start` multiplied with the `amtPerSec` of the drip results in the total amount spend for one drip.  The sum needs to equal the balance `b`.

This equation can be solved for x (defaultEnd).

$$
x = \frac{b +  a_1*s_1 +  a_2*s_2}{ a_1  + a_2}
$$

$$
x = \frac{b +  a_1 s_1 +  a_2 s_2}{ a_1  + a_2}  
$$

**Default End Formular for n default drips**

$$
x = \frac{b +  a_1 s_1 + ... + a_n s_n}{ a_1 + ... + a_n}  
$$

### Trade-offs
This new design reduces the complexity of the code and will be more gas efficient. 

However, it requires a slightly change in the behavior of the system. 

In the current design the defaultDrips array can contain drips which can't be covered. This means the `defaultEnd` is smaller than the start time of the drips.

Currently, we would not add this uncovered default drips to the delta timeline. They are basically ignored when iterating over the list. 

In the new design, we would need to `revert` if a user adds new default start drips which can't be covered. 

### Open Questions
If our formula results in a defaultEnd timestamp that is smaller than the highest default start date. We are in a scenario, where not all default drips can be covered. In this case, we would revert.

- Is this assumption always true?
- Can we prove it?

### Implementation
- implements described algorithm from above
- removes the DefaultDrips struct and helper functions for generating the array