### PR TITLE
Switch default end calculation to binary search 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "radicle-drips-hub",
     "license": "GPL-3.0-only",
     "devDependencies": {
-        "prettier": "^2.4.0",
-        "prettier-plugin-solidity": "https://github.com/prettier-solidity/prettier-plugin-solidity.git#fc77fd6eff0c232d84ff50a147592a94b62e03d7",
+        "prettier": "^2.7.1",
+        "prettier-plugin-solidity": "1.0.0-dev.23",
         "solhint": "^3.3.7",
         "solhint-plugin-prettier": "^0.0.5"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,17 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@solidity-parser/parser@0.14.2-beta.1", "@solidity-parser/parser@^0.14.1", "@solidity-parser/parser@^0.14.2-beta.1":
+"@solidity-parser/parser@0.14.2-beta.1", "@solidity-parser/parser@^0.14.1":
   version "0.14.2-beta.1"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.2-beta.1.tgz#114dc7ff21b913b5eaf80a85123a77a5d53e22e1"
   integrity sha512-UU/LD1nG4XjZ4D9FxpjHeG5/i5MXc3CwJHIvLRI90sn+Ij9cGSyq9sBnSLGAubyhYULnH4/lB3pcbkXB9iO3MA==
+  dependencies:
+    antlr4ts "^0.5.0-alpha.4"
+
+"@solidity-parser/parser@^0.14.3":
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.3.tgz#0d627427b35a40d8521aaa933cc3df7d07bfa36f"
+  integrity sha512-29g2SZ29HtsqA58pLCtopI1P/cPy5/UAzlcAXO6T/CNJimG6yA8kx4NaseMyJULiC+TEs02Y9/yeHzClqoA0hw==
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
 
@@ -710,11 +717,12 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-"prettier-plugin-solidity@https://github.com/prettier-solidity/prettier-plugin-solidity.git#fc77fd6eff0c232d84ff50a147592a94b62e03d7":
-  version "1.0.0-beta.19"
-  resolved "https://github.com/prettier-solidity/prettier-plugin-solidity.git#fc77fd6eff0c232d84ff50a147592a94b62e03d7"
+prettier-plugin-solidity@1.0.0-dev.23:
+  version "1.0.0-dev.23"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-dev.23.tgz#e1edf0693d69fe1518519ab704d5e46ee4f842fc"
+  integrity sha512-440/jZzvtDJcqtoRCQiigo1DYTPAZ85pjNg7gvdd+Lds6QYgID8RyOdygmudzHdFmV2UfENt//A8tzx7iS58GA==
   dependencies:
-    "@solidity-parser/parser" "^0.14.2-beta.1"
+    "@solidity-parser/parser" "^0.14.3"
     emoji-regex "^10.1.0"
     escape-string-regexp "^4.0.0"
     semver "^7.3.7"
@@ -726,10 +734,10 @@ prettier@^1.14.3:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-prettier@^2.4.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
-  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 progress@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
Part of https://github.com/radicle-dev/drips-contracts/issues/167 and https://github.com/radicle-dev/drips-contracts/issues/159.

This PR requires an update to prettier, because the old version kept removing the `memory-safe` annotation.