### PR TITLE
Fix fuzz test handling of drips in the past

### DIFF
--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -190,10 +190,9 @@ contract DripsTest is DSTest, PseudoRandomUtils {
             uint32 start = r.config.start();
             if (start == 0) start = updateTime;
             if (duration == 0) duration = defaultEnd - start;
-            if (start < updateTime) duration -= updateTime - start;
-
             // drips was in the past, not added
             if (start + duration < updateTime) duration = 0;
+            else if (start < updateTime) duration -= updateTime - start;
 
             uint256 expectedAmt = duration * r.config.amtPerSec();
             (uint128 actualAmt, ) = Drips.receiveDrips(


### PR DESCRIPTION
Fixes the failing `0x501f37061efca6c824b8a8506d7074552261465b6d8dda8fe1e6354b43e29c53` seed case which crashed https://github.com/radicle-dev/drips-contracts/runs/7424364922#step:9:72.