### PR TITLE
Add caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ Set up environment variables configuring the deployed contracts:
 export GOVERNANCE="<ADDRESS>"
 
 # OPTIONAL
+# Address of Caller to use. If not set, a new instance is deployed.
+# If set to zero, newly deployed Caller-aware contracts don't get support for Caller.
+export CALLER="<ADDRESS>"
+
+# OPTIONAL
 # Address of Reserve to use. If not set, a new instance is deployed.
 export RESERVE="<ADDRESS>"
 

--- a/src/Caller.sol
+++ b/src/Caller.sol
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.15;
+
+import {Address} from "openzeppelin-contracts/utils/Address.sol";
+import {ECDSA, EIP712} from "openzeppelin-contracts/utils/cryptography/draft-EIP712.sol";
+import {ERC2771Context} from "openzeppelin-contracts/metatx/ERC2771Context.sol";
+
+/// @notice Description of a call.
+/// @param to The called address.
+/// @param data The calldata to be used for the call.
+/// @param value The value of the call.
+struct Call {
+    address to;
+    bytes data;
+    uint256 value;
+}
+
+/// @notice A generic call executor increasing flexibility of other smart contracts' APIs.
+/// It offers 3 main features, which can be mixed and matched for even more flexibility:
+/// - Authorizing addresses to act on behalf of other addresses
+/// - Support for EIP-712 messages
+/// - Batching calls
+///
+/// `Caller` adds these features to the APIs of all smart contracts reading the message
+/// sender passed as per ERC-2771 and accepting this contract as a trusted forwarder.
+/// To all other contracts `Caller` adds a feature of batching calls
+/// for all functions tolerating `msg.sender` being an instance of `Caller`.
+///
+/// Usage examples:
+/// - Batching sequences of calls to a contract.
+/// The contract API may consist of many functions which need to be called in sequence,
+/// but it may not offer a composite functions performing exactly that sequence.
+/// It's expensive, slow and unreliable to create a separate transaction for each step.
+/// To solve that problem create a batch of calls and submit it to `callBatched`.
+/// - Batching sequences of calls to multiple contracts.
+/// It's a common pattern to submit an ERC-2612 permit to approve a smart contract
+/// to spend the user's ERC-20 tokens before running that contract's logic.
+/// Unfortunately unless the contract's API accepts signed messages for the token it requires
+/// creating two separate transactions making it as inconvenient as a regular approval.
+/// The solution is again to use `callBatched` because it can call multiple contracts.
+/// Just create a batch first calling the ERC-20 contract and then the contract needing the tokens.
+/// - Setting up a proxy address.
+/// Sometimes a secure but inconvenient to use address like a cold wallet
+/// or a multisig needs to have a proxy or an operator.
+/// That operator is temporarily trusted, but later it must be revoked or rotated.
+/// To achieve this first `authorize` the proxy using the safe address and then use that proxy
+/// to act on behalf of the secure address using `callAs`.
+/// Later, when the proxy address needs to be revoked, either the secure address or the proxy itself
+/// can `unauthorize` the proxy address and maybe `authorize` another address.
+/// - Setting up operations callable by others.
+/// Some operations may benefit from being callable either by trusted addresses or by anybody.
+/// To achieve this deploy a smart contract executing these operations
+/// via `callAs` and, if you need that too, implementing a custom authorization.
+/// Finally, `authorize` this smart contract to act on behalf of your address.
+/// - Batching dynamic sequences of calls.
+/// Some operations need to react dynamically to the state of the blockchain.
+/// For example an unknown amount of funds is retrieved from a smart contract,
+/// which then needs to be dynamically split and used for different purposes.
+/// To do this, first deploy a smart contract performing that logic.
+/// Next, call `callBatched` which first calls `authorize` on the `Caller` itself authorizing
+/// the new contract to perform `callAs`, then calls that contract and finally `unauthorize`s it.
+/// This way the contract can perform any logic it needs on behalf of your address, but only once.
+/// - Gasless transactions.
+/// It's an increasingly common pattern to use smart contracts without necessarily spending Ether.
+/// This is achieved with gasless transactions where the wallet signs an ERC-712 message
+/// and somebody else submits the actual transaction executing what the message requests.
+/// It may be executed by another wallet or by an operator
+/// expecting to be repaid for the spent Ether in other assets.
+/// You can achieve this with `callSigned`, which allows anybody
+/// to execute a call on behalf of the signer of a message.
+/// `Caller` doesn't deal with gas, so if you're using a gasless network,
+/// it may require you to specify the gas needed for the entire call execution.
+/// - Executing batched calls with authorization or signature.
+/// You can use both `callAs` and `callSigned` to call `Caller` itself,
+/// which in turn can execute batched calls on behalf of the authorizing or signing address.
+/// It also applies to `authorize` and `unauthorize`, they too can be called using
+/// `callAs`, `callSigned` or `callBatched`.
+contract Caller is EIP712("Caller", "1"), ERC2771Context(address(this)) {
+    string internal constant CALL_SIGNED_TYPE_NAME = "CallSigned("
+        "address sender,address to,bytes data,uint256 value,uint256 nonce,uint256 deadline)";
+    bytes32 internal immutable callSignedTypeHash = keccak256(bytes(CALL_SIGNED_TYPE_NAME));
+
+    /// @notice True if the address authorizes another address to make calls on its behalf.
+    /// The first address is the authorizing one and the second address is the authorized one.
+    mapping(address => mapping(address => bool)) public isAuthorized;
+    /// @notice The nonce which needs to be used in the next EIP-712 message signed by the address.
+    mapping(address => uint256) public nonce;
+
+    /// @notice Emitted when granting the authorization
+    /// of an address to make calls on behalf of the `sender`.
+    /// @param sender The authorizing address.
+    /// @param authorized The authorized address.
+    event Authorized(address indexed sender, address indexed authorized);
+
+    /// @notice Emitted when revoking the authorization
+    /// of an address to make calls on behalf of the `sender`.
+    /// @param sender The authorizing address.
+    /// @param unauthorized The authorized address.
+    event Unauthorized(address indexed sender, address indexed unauthorized);
+
+    /// @notice Grants the authorization of an address to make calls on behalf of the sender.
+    /// @param authorized The authorized address.
+    function authorize(address authorized) public {
+        address sender = _msgSender();
+        isAuthorized[sender][authorized] = true;
+        emit Authorized(sender, authorized);
+    }
+
+    /// @notice Revokes the authorization of an address to make calls on behalf of the sender.
+    /// @param unauthorized The unauthorized address.
+    function unauthorize(address unauthorized) public {
+        address sender = _msgSender();
+        isAuthorized[sender][unauthorized] = false;
+        emit Unauthorized(sender, unauthorized);
+    }
+
+    /// @notice Makes a call on behalf of the `sender`.
+    /// Callable only by an address currently `authorize`d by the `sender`.
+    /// Reverts if the call reverts or the called address is not a smart contract.
+    /// @param sender The sender to be set as the message sender of the call as per ERC-2771.
+    /// @param to The called address.
+    /// @param data The calldata to be used for the call.
+    /// @return returnData The data returned by the call.
+    function callAs(address sender, address to, bytes memory data)
+        public
+        payable
+        returns (bytes memory returnData)
+    {
+        require(isAuthorized[sender][_msgSender()], "Not authorized");
+        return _call(sender, to, data, msg.value);
+    }
+
+    /// @notice Makes a call on behalf of the `sender`.
+    /// Requires a `sender`'s signature of an ERC-721 message approving the call.
+    /// Reverts if the call reverts or the called address is not a smart contract.
+    /// @param sender The sender to be set as the message sender of the call as per ERC-2771.
+    /// @param to The called address.
+    /// @param data The calldata to be used for the call.
+    /// @param deadline The timestamp until which the message signature is valid.
+    /// @param r The `r` part of the compact message signature as per EIP-2098.
+    /// @param sv The `sv` part of the compact message signature as per EIP-2098.
+    /// @return returnData The data returned by the call.
+    function callSigned(
+        address sender,
+        address to,
+        bytes memory data,
+        uint256 deadline,
+        bytes32 r,
+        bytes32 sv
+    )
+        public
+        payable
+        returns (bytes memory returnData)
+    {
+        require(block.timestamp <= deadline, "Execution deadline expired");
+        uint256 currNonce = nonce[sender]++;
+        bytes32 executeHash = keccak256(
+            abi.encode(
+                callSignedTypeHash, sender, to, keccak256(data), msg.value, currNonce, deadline
+            )
+        );
+        address signer = ECDSA.recover(_hashTypedDataV4(executeHash), r, sv);
+        require(signer == sender, "Invalid signature");
+        return _call(sender, to, data, msg.value);
+    }
+
+    /// @notice Executes a batch of calls.
+    /// The caller will be set as the message sender of all the calls as per ERC-2771.
+    /// Reverts if any of the calls reverts or any of the called addresses is not a smart contract.
+    /// @param calls The calls to perform.
+    function callBatched(Call[] memory calls) public payable {
+        address sender = _msgSender();
+        for (uint256 i = 0; i < calls.length; i++) {
+            Call memory call = calls[i];
+            _call(sender, call.to, call.data, call.value);
+        }
+    }
+
+    function _call(address sender, address to, bytes memory data, uint256 value)
+        internal
+        returns (bytes memory returnData)
+    {
+        // Encode the message sender as per ERC-2771
+        return Address.functionCallWithValue(to, abi.encodePacked(data, sender), value);
+    }
+}

--- a/src/test/Caller.t.sol
+++ b/src/test/Caller.t.sol
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.15;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC2771Context} from "openzeppelin-contracts/metatx/ERC2771Context.sol";
+import {Address} from "openzeppelin-contracts/utils/Address.sol";
+import {ECDSA} from "openzeppelin-contracts/utils/cryptography/ECDSA.sol";
+import {Call, Caller} from "../Caller.sol";
+
+contract CallerTest is Test {
+    string internal constant DOMAIN_TYPE_NAME =
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)";
+    bytes32 internal immutable domainTypeHash = keccak256(bytes(DOMAIN_TYPE_NAME));
+    string internal constant CALL_SIGNED_TYPE_NAME = "CallSigned("
+        "address sender,address to,bytes data,uint256 value,uint256 nonce,uint256 deadline)";
+    bytes32 internal immutable callSignedTypeHash = keccak256(bytes(CALL_SIGNED_TYPE_NAME));
+
+    Caller internal caller;
+    Target internal target;
+    Target internal targetOtherForwarder;
+    bytes32 internal callerDomainSeparator;
+    uint256 internal senderKey;
+    address internal sender;
+
+    constructor() {
+        caller = new Caller();
+        bytes32 nameHash = keccak256("Caller");
+        bytes32 versionHash = keccak256("1");
+        callerDomainSeparator = keccak256(
+            abi.encode(domainTypeHash, nameHash, versionHash, block.chainid, address(caller))
+        );
+        target = new Target(address(caller));
+        targetOtherForwarder = new Target(address(0));
+        senderKey = uint256(keccak256("I'm the sender"));
+        sender = vm.addr(senderKey);
+    }
+
+    function testCallSigned() public {
+        uint256 input = 1234567890;
+        bytes memory data = abi.encodeWithSelector(target.run.selector, input);
+        uint256 value = 4321;
+        uint256 deadline = block.timestamp;
+        (bytes32 r, bytes32 sv) = signCall(senderKey, target, data, value, 0, deadline);
+
+        bytes memory returned =
+            caller.callSigned{value: value}(sender, address(target), data, deadline, r, sv);
+
+        assertEq(abi.decode(returned, (uint256)), input + 1, "Invalid returned value");
+        target.verify(sender, input, value);
+    }
+
+    function testCallSignedRejectsExpiredDeadline() public {
+        bytes memory data = abi.encodeWithSelector(target.run.selector, 1);
+        uint256 deadline = block.timestamp;
+        skip(1);
+        (bytes32 r, bytes32 sv) = signCall(senderKey, target, data, 0, 0, deadline);
+
+        try caller.callSigned(sender, address(target), data, deadline, r, sv) {
+            assertTrue(false, "CallSigned hasn't reverted");
+        } catch Error(string memory reason) {
+            assertEq(reason, "Execution deadline expired", "Invalid callSigned revert reason");
+        }
+    }
+
+    function testCallSignedRejectsInvalidNonce() public {
+        bytes memory data = abi.encodeWithSelector(target.run.selector, 1);
+        uint256 deadline = block.timestamp;
+        (bytes32 r, bytes32 sv) = signCall(senderKey, target, data, 0, 0, deadline);
+        caller.callSigned(sender, address(target), data, deadline, r, sv);
+        assertEq(caller.nonce(sender), 1, "Invalid nonce after a signed call");
+
+        try caller.callSigned(sender, address(target), data, deadline, r, sv) {
+            assertTrue(false, "CallSigned hasn't reverted");
+        } catch Error(string memory reason) {
+            assertEq(reason, "Invalid signature", "Invalid callSigned revert reason");
+        }
+    }
+
+    function testCallSignedRejectsInvalidSigner() public {
+        bytes memory data = abi.encodeWithSelector(target.run.selector, 1);
+        uint256 deadline = block.timestamp;
+        (bytes32 r, bytes32 sv) = signCall(senderKey + 1, target, data, 0, 0, deadline);
+
+        try caller.callSigned(sender, address(target), data, deadline, r, sv) {
+            assertTrue(false, "CallSigned hasn't reverted");
+        } catch Error(string memory reason) {
+            assertEq(reason, "Invalid signature", "Invalid callSigned revert reason");
+        }
+    }
+
+    function testCallSignedBubblesErrors() public {
+        // Zero input triggers a revert in Target
+        bytes memory data = abi.encodeWithSelector(target.run.selector, 0);
+        uint256 deadline = block.timestamp;
+        (bytes32 r, bytes32 sv) = signCall(senderKey, target, data, 0, 0, deadline);
+
+        try caller.callSigned(sender, address(target), data, deadline, r, sv) {
+            assertTrue(false, "CallSigned hasn't reverted");
+        } catch Error(string memory reason) {
+            assertEq(reason, "Input is zero", "Invalid callSigned revert reason");
+        }
+    }
+
+    function testCallAs() public {
+        uint256 input = 1234567890;
+        bytes memory data = abi.encodeWithSelector(target.run.selector, input);
+        uint256 value = 4321;
+        authorize(sender, address(this));
+
+        bytes memory returned = caller.callAs{value: value}(sender, address(target), data);
+
+        assertEq(abi.decode(returned, (uint256)), input + 1, "Invalid returned value");
+        target.verify(sender, input, value);
+    }
+
+    function testCallAsRejectsWhenNotAuthorized() public {
+        bytes memory data = abi.encodeWithSelector(target.run.selector, 1);
+
+        try caller.callAs(sender, address(target), data) {
+            assertTrue(false, "CallAs hasn't reverted");
+        } catch Error(string memory reason) {
+            assertEq(reason, "Not authorized", "Invalid callAs revert reason");
+        }
+    }
+
+    function testCallAsRejectsWhenUnauthorized() public {
+        bytes memory data = abi.encodeWithSelector(target.run.selector, 1);
+        authorize(sender, address(this));
+        unauthorize(sender, address(this));
+
+        try caller.callAs(sender, address(target), data) {
+            assertTrue(false, "CallAs hasn't reverted");
+        } catch Error(string memory reason) {
+            assertEq(reason, "Not authorized", "Invalid callAs revert reason");
+        }
+    }
+
+    function testCallAsBubblesErrors() public {
+        // Zero input triggers a revert in Target
+        bytes memory data = abi.encodeWithSelector(target.run.selector, 0);
+        authorize(sender, address(this));
+
+        try caller.callAs(sender, address(target), data) {
+            assertTrue(false, "CallAs hasn't reverted");
+        } catch Error(string memory reason) {
+            assertEq(reason, "Input is zero", "Invalid callAs revert reason");
+        }
+    }
+
+    function testCallBatched() public {
+        uint256 input1 = 1234567890;
+        uint256 input2 = 2468024680;
+        uint256 value1 = 4321;
+        uint256 value2 = 8642;
+        Call[] memory calls = new Call[](2);
+        calls[0] = Call({
+            to: address(target),
+            data: abi.encodeWithSelector(target.run.selector, input1),
+            value: value1
+        });
+        calls[1] = Call({
+            to: address(targetOtherForwarder),
+            data: abi.encodeWithSelector(target.run.selector, input2),
+            value: value2
+        });
+
+        caller.callBatched{value: value1 + value2}(calls);
+
+        target.verify(address(this), input1, value1);
+        targetOtherForwarder.verify(address(caller), input2, value2);
+    }
+
+    function testCallBatchedBubblesErrors() public {
+        Call[] memory calls = new Call[](2);
+        calls[0] = Call({
+            to: address(target),
+            data: abi.encodeWithSelector(target.run.selector, 1234567890),
+            value: 0
+        });
+        // Zero input triggers a revert in Target
+        calls[1] = Call({
+            to: address(targetOtherForwarder),
+            data: abi.encodeWithSelector(target.run.selector, 0),
+            value: 0
+        });
+
+        try caller.callBatched(calls) {
+            assertTrue(false, "CallBatched hasn't reverted");
+        } catch Error(string memory reason) {
+            assertEq(reason, "Input is zero", "Invalid callBatched revert reason");
+        }
+
+        // The effects of the first call are reverted
+        target.verify(address(0), 0, 0);
+    }
+
+    function testCallerCanCallOnItselfCallAs() public {
+        Call[] memory calls = new Call[](1);
+        bytes memory data = abi.encodeWithSelector(target.run.selector, 1);
+        calls[0] = Call({
+            to: address(caller),
+            data: abi.encodeWithSelector(caller.callAs.selector, sender, address(target), data),
+            value: 0
+        });
+        authorize(sender, address(this));
+
+        caller.callBatched(calls);
+
+        target.verify(sender, 1, 0);
+    }
+
+    function testCallerCanCallOnItselfAuthorize() public {
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({
+            to: address(caller),
+            data: abi.encodeWithSelector(caller.authorize.selector, sender),
+            value: 0
+        });
+
+        caller.callBatched(calls);
+
+        assertTrue(caller.isAuthorized(address(this), sender), "Not authorized");
+    }
+
+    function testCallerCanCallOnItselfUnuthorize() public {
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({
+            to: address(caller),
+            data: abi.encodeWithSelector(caller.unauthorize.selector, sender),
+            value: 0
+        });
+        caller.authorize(sender);
+
+        caller.callBatched(calls);
+
+        assertFalse(caller.isAuthorized(address(this), sender), "Not unauthorized");
+    }
+
+    function testCallerCanCallOnItselfCallBatched() public {
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({
+            to: address(target),
+            data: abi.encodeWithSelector(target.run.selector, 1),
+            value: 0
+        });
+        authorize(sender, address(this));
+        bytes memory data = abi.encodeWithSelector(caller.callBatched.selector, calls);
+        authorize(sender, address(this));
+
+        caller.callAs(sender, address(caller), data);
+
+        target.verify(sender, 1, 0);
+    }
+
+    function authorize(address authorizing, address authorized) internal {
+        vm.prank(authorizing);
+        caller.authorize(authorized);
+    }
+
+    function unauthorize(address authorizing, address unauthorized) internal {
+        vm.prank(authorizing);
+        caller.unauthorize(unauthorized);
+    }
+
+    function signCall(
+        uint256 privKey,
+        Target to,
+        bytes memory data,
+        uint256 value,
+        uint256 nonce,
+        uint256 deadline
+    )
+        internal
+        returns (bytes32 r, bytes32 sv)
+    {
+        bytes memory payload = abi.encode(
+            callSignedTypeHash,
+            vm.addr(privKey),
+            address(to),
+            keccak256(data),
+            value,
+            nonce,
+            deadline
+        );
+        bytes32 digest = ECDSA.toTypedDataHash(callerDomainSeparator, keccak256(payload));
+        uint8 v;
+        bytes32 s;
+        (v, r, s) = vm.sign(privKey, digest);
+        sv = (s << 1 >> 1) | (bytes32(uint256(v) - 27) << 255);
+    }
+}
+
+contract Target is ERC2771Context, Test {
+    address public sender;
+    uint256 public input;
+    uint256 public value;
+
+    constructor(address forwarder) ERC2771Context(forwarder) {
+        return;
+    }
+
+    function run(uint256 input_) public payable returns (uint256) {
+        require(input_ > 0, "Input is zero");
+        sender = _msgSender();
+        input = input_;
+        value = msg.value;
+        return input + 1;
+    }
+
+    function verify(address expectedSender, uint256 expectedInput, uint256 expectedValue) public {
+        assertEq(sender, expectedSender, "Invalid sender");
+        assertEq(input, expectedInput, "Invalid input");
+        assertEq(value, expectedValue, "Invalid value");
+    }
+}

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -41,7 +41,7 @@ contract DripsHubTest is DripsHubUserUtils {
         dripsHub = DripsHub(address(new Proxy(hubLogic, address(this))));
         reserve.addUser(address(dripsHub));
         uint32 addressAppId = dripsHub.registerApp(address(this));
-        addressApp = new AddressApp(dripsHub, addressAppId);
+        addressApp = new AddressApp(dripsHub, address(0), addressAppId);
         dripsHub.updateAppAddress(addressAppId, address(addressApp));
         admin = new ManagedUser(dripsHub);
         nonAdmin = new ManagedUser(dripsHub);


### PR DESCRIPTION
Closes https://github.com/radicle-dev/drips-contracts/issues/192.
Makes https://github.com/radicle-dev/drips-contracts/issues/183 more reasonable.
Makes https://github.com/radicle-dev/drips-contracts/issues/103 more feasible if we choose to go with the `AutomationApp` approach.

It's a minimalistic solution, which seems to still manage to cover all the use cases which we need while staying simple and easily auditable.

It follows ERC-2771, so on the app side all that's needed is deriving from [ERC2771Context](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/metatx/ERC2771Context.sol) and then using `_msgSender()` instead of `msg.sender`. See changes made to `AddressApp`.

### An example of how a signature for `callSigned` can be generated with ethers.js:
```ts
// https://codesandbox.io/s/typescript-playground-export-forked-feumq1

import * as ethers from "ethers";

async function main() {
  const wallet = new ethers.Wallet(ethers.utils.hexZeroPad("0x01", 32));
  const sender = wallet.address;
  console.log("Address: " + sender);

  const domain = {
    name: "Caller",
    version: "1",
    chainId: 31337,
    verifyingContract: "0xCe71065D4017F316EC606Fe4422e11eB2c47c246"
  };
  const types = {
    CallSigned: [
      { type: "address", name: "sender" },
      { type: "address", name: "to" },
      { type: "bytes", name: "data" },
      { type: "uint256", name: "value" },
      { type: "uint256", name: "nonce" },
      { type: "uint256", name: "deadline" }
    ]
  };
  // If possible, use the interfaces generated from the ABIs
  const iface = new ethers.utils.Interface(["function foo(uint256 input)"]);
  const value = {
    sender: sender,
    to: "0x185a4dc360CE69bDCceE33b3784B0282f7961aea",
    data: iface.encodeFunctionData("foo", [1234567890]),
    value: 4321,
    nonce: 0,
    deadline: ethers.constants.MaxUint256.toString()
  };
  const signatureRaw = await wallet._signTypedData(domain, types, value);
  const signature = ethers.utils.splitSignature(signatureRaw);
  console.log("r: " + signature.r);
  console.log("sv: " + signature.yParityAndS);
}

main();
```