### PR TITLE
Consistent "*Result" function naming

### DIFF
--- a/src/Drips.sol
+++ b/src/Drips.sol
@@ -327,7 +327,7 @@ abstract contract Drips {
         uint256 squeezedNum;
         uint256[] memory squeezedIdxs;
         (amt, squeezedNum, squeezedIdxs) =
-            _squeezableDrips(userId, assetId, senderId, historyHash, dripsHistory);
+            _squeezeDripsResult(userId, assetId, senderId, historyHash, dripsHistory);
         DripsState storage state = _dripsStorage().states[assetId][userId];
         uint32[2 ** 32] storage nextSqueezed = state.nextSqueezed[senderId];
         for (uint256 i = 0; i < squeezedNum; i++) {
@@ -348,7 +348,7 @@ abstract contract Drips {
     /// @return amt The squeezed amount.
     /// @return squeezedNum The number of squeezed history entries.
     /// @return squeezedIdxs The `nextSqueezed` indexes of squeezed history entries.
-    function _squeezableDrips(
+    function _squeezeDripsResult(
         uint256 userId,
         uint256 assetId,
         uint256 senderId,

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -277,17 +277,17 @@ contract DripsHub is Managed, Drips, Splits {
         return Splits._splittable(userId, _assetId(erc20));
     }
 
-    /// @notice Calculate results of splitting an amount using the current splits configuration.
+    /// @notice Calculate the result of splitting an amount using the current splits configuration.
     /// @param userId The user ID
     /// @param currReceivers The list of the user's current splits receivers.
     /// @param amount The amount being split.
     /// @return collectableAmt The part of the `amount` left for collection after splitting.
-    function splitResults(uint256 userId, SplitsReceiver[] memory currReceivers, uint128 amount)
+    function splitResult(uint256 userId, SplitsReceiver[] memory currReceivers, uint128 amount)
         public
         view
         returns (uint128 collectableAmt)
     {
-        return Splits._splitResults(userId, currReceivers, amount);
+        return Splits._splitResult(userId, currReceivers, amount);
     }
 
     /// @notice Splits user's received but not split yet funds among receivers.

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -190,12 +190,13 @@ contract DripsHub is Managed, Drips, Splits {
     /// If too high, receiving may become too expensive to fit in a single transaction.
     /// @return receivableAmt The amount which would be received
     /// @return receivableCycles The number of cycles which would still be receivable after the call
-    function receivableDrips(uint256 userId, IERC20 erc20, uint32 maxCycles)
+    function receiveDripsResult(uint256 userId, IERC20 erc20, uint32 maxCycles)
         public
         view
         returns (uint128 receivableAmt, uint32 receivableCycles)
     {
-        return Drips._receivableDrips(userId, _assetId(erc20), maxCycles);
+        (receivableAmt, receivableCycles,,,) =
+            Drips._receiveDripsResult(userId, _assetId(erc20), maxCycles);
     }
 
     /// @notice Receive drips for the user.

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -258,7 +258,7 @@ contract DripsHub is Managed, Drips, Splits {
     /// @param historyHash The sender's history hash which was valid right before `dripsHistory`.
     /// @param dripsHistory The sequence of the sender's drips configurations.
     /// @return amt The squeezed amount.
-    function squeezableDrips(
+    function squeezeDripsResult(
         uint256 userId,
         IERC20 erc20,
         uint256 senderId,
@@ -266,7 +266,7 @@ contract DripsHub is Managed, Drips, Splits {
         DripsHistory[] memory dripsHistory
     ) public view returns (uint128 amt) {
         (amt,,) =
-            Drips._squeezableDrips(userId, _assetId(erc20), senderId, historyHash, dripsHistory);
+            Drips._squeezeDripsResult(userId, _assetId(erc20), senderId, historyHash, dripsHistory);
     }
 
     /// @notice Returns user's received but not split yet funds.

--- a/src/Splits.sol
+++ b/src/Splits.sol
@@ -103,12 +103,12 @@ abstract contract Splits {
         return _splitsStorage().splitsStates[userId].balances[assetId].splittable;
     }
 
-    /// @notice Calculate results of splitting an amount using the current splits configuration.
+    /// @notice Calculate the result of splitting an amount using the current splits configuration.
     /// @param userId The user ID
     /// @param currReceivers The list of the user's current splits receivers.
     /// @param amount The amount being split.
     /// @return collectableAmt The part of the `amount` left for collection after splitting.
-    function _splitResults(uint256 userId, SplitsReceiver[] memory currReceivers, uint128 amount)
+    function _splitResult(uint256 userId, SplitsReceiver[] memory currReceivers, uint128 amount)
         internal
         view
         returns (uint128 collectableAmt)

--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -379,8 +379,8 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
         uint128 expectedTotalAmt = expectedReceivedAmt + expectedAmtAfter;
         uint32 expectedTotalCycles = expectedReceivedCycles + expectedCyclesAfter;
         assertReceivableDripsCycles(userId, expectedTotalCycles);
-        assertReceivableDrips(userId, type(uint32).max, expectedTotalAmt, 0);
-        assertReceivableDrips(userId, maxCycles, expectedReceivedAmt, expectedCyclesAfter);
+        assertReceiveDripsResult(userId, type(uint32).max, expectedTotalAmt, 0);
+        assertReceiveDripsResult(userId, maxCycles, expectedReceivedAmt, expectedCyclesAfter);
 
         (uint128 receivedAmt, uint32 receivableCycles) =
             Drips._receiveDrips(userId, assetId, maxCycles);
@@ -388,7 +388,7 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
         assertEq(receivedAmt, expectedReceivedAmt, "Invalid amount received from drips");
         assertEq(receivableCycles, expectedCyclesAfter, "Invalid receivable drips cycles left");
         assertReceivableDripsCycles(userId, expectedCyclesAfter);
-        assertReceivableDrips(userId, type(uint32).max, expectedAmtAfter, 0);
+        assertReceiveDripsResult(userId, type(uint32).max, expectedAmtAfter, 0);
     }
 
     function receiveDrips(DripsReceiver[] memory receivers, uint32 maxEnd, uint32 updateTime)
@@ -430,19 +430,19 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
         assertEq(actualCycles, expectedCycles, "Invalid total receivable drips cycles");
     }
 
-    function assertReceivableDrips(uint256 userId, uint128 expectedAmt) internal {
-        (uint128 actualAmt,) = Drips._receivableDrips(userId, assetId, type(uint32).max);
+    function assertReceiveDripsResult(uint256 userId, uint128 expectedAmt) internal {
+        (uint128 actualAmt,,,,) = Drips._receiveDripsResult(userId, assetId, type(uint32).max);
         assertEq(actualAmt, expectedAmt, "Invalid receivable amount");
     }
 
-    function assertReceivableDrips(
+    function assertReceiveDripsResult(
         uint256 userId,
         uint32 maxCycles,
         uint128 expectedAmt,
         uint32 expectedCycles
     ) internal {
-        (uint128 actualAmt, uint32 actualCycles) =
-            Drips._receivableDrips(userId, assetId, maxCycles);
+        (uint128 actualAmt, uint32 actualCycles,,,) =
+            Drips._receiveDripsResult(userId, assetId, maxCycles);
         assertEq(actualAmt, expectedAmt, "Invalid receivable amount");
         assertEq(actualCycles, expectedCycles, "Invalid receivable drips cycles");
     }
@@ -749,11 +749,11 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
         // The first cycle hasn't been dripping
         skipToCycleEnd();
         assertReceivableDripsCycles(receiver, 0);
-        assertReceivableDrips(receiver, 0);
+        assertReceiveDripsResult(receiver, 0);
         // The second cycle hasn't been dripping
         skipToCycleEnd();
         assertReceivableDripsCycles(receiver, 0);
-        assertReceivableDrips(receiver, 0);
+        assertReceiveDripsResult(receiver, 0);
         // The third cycle has been dripping
         skipToCycleEnd();
         assertReceivableDripsCycles(receiver, 1);
@@ -817,7 +817,7 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
         uint128 amt = amtPerSec * secs * 2;
         setDrips(sender, 0, amt, recv(receiver, amtPerSec, block.timestamp + cycleSecs - secs, 0));
         skipToCycleEnd();
-        assertReceivableDrips(receiver, amt / 2);
+        assertReceiveDripsResult(receiver, amt / 2);
         skipToCycleEnd();
         receiveDrips(receiver, amt);
     }
@@ -860,7 +860,7 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
         assertBalance(sender, 0);
         skipToCycleEnd();
         // Receiver had 10 seconds paying 10 per second
-        assertReceivableDrips(receiver, 100);
+        assertReceiveDripsResult(receiver, 100);
         changeBalance(sender, 0, 60);
         skip(5);
         // Sender had 5 seconds paying 10 per second

--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -464,14 +464,14 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
         uint256 expectedAmt
     ) internal {
         (uint128 amtBefore,,) =
-            Drips._squeezableDrips(userId, assetId, senderId, historyHash, dripsHistory);
+            Drips._squeezeDripsResult(userId, assetId, senderId, historyHash, dripsHistory);
         assertEq(amtBefore, expectedAmt, "Invalid squeezable amount before squeezing");
 
         uint128 amt = Drips._squeezeDrips(userId, assetId, senderId, historyHash, dripsHistory);
 
         assertEq(amt, expectedAmt, "Invalid squeezed amount");
         (uint128 amtAfter,,) =
-            Drips._squeezableDrips(userId, assetId, senderId, historyHash, dripsHistory);
+            Drips._squeezeDripsResult(userId, assetId, senderId, historyHash, dripsHistory);
         assertEq(amtAfter, 0, "Squeezable amount after squeezing non-zero");
     }
 
@@ -484,6 +484,8 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
     ) internal {
         vm.expectRevert(expectedReason);
         this.squeezeDripsExternal(userId, senderId, historyHash, dripsHistory);
+        vm.expectRevert(expectedReason);
+        this.squeezeDripsResultExternal(userId, senderId, historyHash, dripsHistory);
     }
 
     function squeezeDripsExternal(
@@ -495,24 +497,13 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
         Drips._squeezeDrips(userId, assetId, senderId, historyHash, dripsHistory);
     }
 
-    function assertSqueezableDripsReverts(
-        uint256 userId,
-        uint256 senderId,
-        bytes32 historyHash,
-        DripsHistory[] memory dripsHistory,
-        bytes memory expectedReason
-    ) internal {
-        vm.expectRevert(expectedReason);
-        this.squeezableDripsExternal(userId, senderId, historyHash, dripsHistory);
-    }
-
-    function squeezableDripsExternal(
+    function squeezeDripsResultExternal(
         uint256 userId,
         uint256 senderId,
         bytes32 historyHash,
         DripsHistory[] memory dripsHistory
     ) external view {
-        Drips._squeezableDrips(userId, assetId, senderId, historyHash, dripsHistory);
+        Drips._squeezeDripsResult(userId, assetId, senderId, historyHash, dripsHistory);
     }
 
     function testDripsConfigStoresParameters() public {

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -278,7 +278,7 @@ contract DripsHubTest is Test {
     function collectAll(uint256 forUser, uint128 expectedCollected, uint128 expectedSplit)
         internal
     {
-        (uint128 receivable,) = dripsHub.receivableDrips(forUser, erc20, type(uint32).max);
+        (uint128 receivable,) = dripsHub.receiveDripsResult(forUser, erc20, type(uint32).max);
         (uint128 received, uint32 receivableCycles) =
             dripsHub.receiveDrips(forUser, erc20, type(uint32).max);
         assertEq(received, receivable, "Invalid received amount");
@@ -308,8 +308,8 @@ contract DripsHubTest is Test {
         uint128 expectedTotalAmt = expectedReceivedAmt + expectedAmtAfter;
         uint32 expectedTotalCycles = expectedReceivedCycles + expectedCyclesAfter;
         assertReceivableDripsCycles(forUser, expectedTotalCycles);
-        assertReceivableDrips(forUser, type(uint32).max, expectedTotalAmt, 0);
-        assertReceivableDrips(forUser, maxCycles, expectedReceivedAmt, expectedCyclesAfter);
+        assertReceiveDripsResult(forUser, type(uint32).max, expectedTotalAmt, 0);
+        assertReceiveDripsResult(forUser, maxCycles, expectedReceivedAmt, expectedCyclesAfter);
 
         (uint128 receivedAmt, uint32 receivableCycles) =
             dripsHub.receiveDrips(forUser, erc20, maxCycles);
@@ -317,7 +317,7 @@ contract DripsHubTest is Test {
         assertEq(receivedAmt, expectedReceivedAmt, "Invalid amount received from drips");
         assertEq(receivableCycles, expectedCyclesAfter, "Invalid receivable drips cycles left");
         assertReceivableDripsCycles(forUser, expectedCyclesAfter);
-        assertReceivableDrips(forUser, type(uint32).max, expectedAmtAfter, 0);
+        assertReceiveDripsResult(forUser, type(uint32).max, expectedAmtAfter, 0);
     }
 
     function assertReceivableDripsCycles(uint256 forUser, uint32 expectedCycles) internal {
@@ -325,14 +325,14 @@ contract DripsHubTest is Test {
         assertEq(actualCycles, expectedCycles, "Invalid total receivable drips cycles");
     }
 
-    function assertReceivableDrips(
+    function assertReceiveDripsResult(
         uint256 forUser,
         uint32 maxCycles,
         uint128 expectedAmt,
         uint32 expectedCycles
     ) internal {
         (uint128 actualAmt, uint32 actualCycles) =
-            dripsHub.receivableDrips(forUser, erc20, maxCycles);
+            dripsHub.receiveDripsResult(forUser, erc20, maxCycles);
         assertEq(actualAmt, expectedAmt, "Invalid receivable amount");
         assertEq(actualCycles, expectedCycles, "Invalid receivable drips cycles");
     }

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -339,7 +339,7 @@ contract DripsHubTest is Test {
 
     function split(uint256 forUser, uint128 expectedCollectable, uint128 expectedSplit) internal {
         assertSplittable(forUser, expectedCollectable + expectedSplit);
-        assertSplitResults(forUser, expectedCollectable + expectedSplit, expectedCollectable);
+        assertSplitResult(forUser, expectedCollectable + expectedSplit, expectedCollectable);
         uint128 collectableBefore = collectable(forUser);
 
         (uint128 collectableAmt, uint128 splitAmt) =
@@ -360,10 +360,10 @@ contract DripsHubTest is Test {
         assertEq(actual, expected, "Invalid splittable");
     }
 
-    function assertSplitResults(uint256 forUser, uint256 amt, uint256 expected) internal {
+    function assertSplitResult(uint256 forUser, uint256 amt, uint256 expected) internal {
         uint128 actual =
-            dripsHub.splitResults(forUser, getCurrSplitsReceivers(forUser), uint128(amt));
-        assertEq(actual, expected, "Invalid split results");
+            dripsHub.splitResult(forUser, getCurrSplitsReceivers(forUser), uint128(amt));
+        assertEq(actual, expected, "Invalid split result");
     }
 
     function collect(uint256 forUser, uint128 expectedAmt) internal {

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -475,7 +475,7 @@ contract DripsHubTest is Test {
 
         // Check squeezableDrips
         skip(1);
-        uint128 amt = dripsHub.squeezableDrips(receiver, erc20, user, 0, history);
+        uint128 amt = dripsHub.squeezeDripsResult(receiver, erc20, user, 0, history);
         assertEq(amt, 1, "Invalid squeezable amt before");
 
         // Squeeze
@@ -484,7 +484,7 @@ contract DripsHubTest is Test {
         assertEq(amt, 1, "Invalid squeezed amt");
 
         // Check squeezableDrips
-        amt = dripsHub.squeezableDrips(receiver, erc20, user, 0, history);
+        amt = dripsHub.squeezeDripsResult(receiver, erc20, user, 0, history);
         assertEq(amt, 0, "Invalid squeezable amt after");
 
         // Collect the squeezed amount


### PR DESCRIPTION
Functions simulating the result of calling a function don't have a transparent and consistent naming. This PR improves that:
- `receivableDrips` doesn't return the total receivable amount, the result depends on the `maxCycles` parameter provided by the user, `receiveDripsResult` reflects that better.
- `squezableDrips` too doesn't return the total amount, just the result dependent on the provided `dripsHistory`, `squeezeDripsResult` reflects that better.
- `splitResults` is a bad name, the `s` at the end is easy to miss, `splitResult` is easier to handle with eyes.