### PR TITLE
Widen drips and splits configuratin sizes from uint8 to uint256

### DIFF
--- a/src/Drips.sol
+++ b/src/Drips.sol
@@ -103,7 +103,7 @@ library DripsConfigImpl {
 abstract contract Drips {
     /// @notice Maximum number of drips receivers of a single user.
     /// Limits cost of changes in drips configuration.
-    uint8 internal constant _MAX_DRIPS_RECEIVERS = 100;
+    uint256 internal constant _MAX_DRIPS_RECEIVERS = 100;
     /// @notice The additional decimals for all amtPerSec values.
     uint8 internal constant _AMT_PER_SEC_EXTRA_DECIMALS = 9;
     /// @notice The multiplier for all amtPerSec values. It's `10 ** _AMT_PER_SEC_EXTRA_DECIMALS`.

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -48,9 +48,8 @@ contract DripsHub is Managed, Drips, Splits {
     uint8 public constant AMT_PER_SEC_EXTRA_DECIMALS = _AMT_PER_SEC_EXTRA_DECIMALS;
     /// @notice The multiplier for all amtPerSec values.
     uint256 public constant AMT_PER_SEC_MULTIPLIER = _AMT_PER_SEC_MULTIPLIER;
-    /// @notice Maximum number of splits receivers of a single user.
-    /// Limits cost of collecting.
-    uint32 public constant MAX_SPLITS_RECEIVERS = _MAX_SPLITS_RECEIVERS;
+    /// @notice Maximum number of splits receivers of a single user. Limits the cost of splitting.
+    uint256 public constant MAX_SPLITS_RECEIVERS = _MAX_SPLITS_RECEIVERS;
     /// @notice The total splits weight of a user
     uint32 public constant TOTAL_SPLITS_WEIGHT = _TOTAL_SPLITS_WEIGHT;
     /// @notice The offset of the controlling driver ID in the user ID.

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -43,7 +43,7 @@ contract DripsHub is Managed, Drips, Splits {
     IReserve public immutable reserve;
     /// @notice Maximum number of drips receivers of a single user.
     /// Limits cost of changes in drips configuration.
-    uint8 public constant MAX_DRIPS_RECEIVERS = _MAX_DRIPS_RECEIVERS;
+    uint256 public constant MAX_DRIPS_RECEIVERS = _MAX_DRIPS_RECEIVERS;
     /// @notice The additional decimals for all amtPerSec values.
     uint8 public constant AMT_PER_SEC_EXTRA_DECIMALS = _AMT_PER_SEC_EXTRA_DECIMALS;
     /// @notice The multiplier for all amtPerSec values.

--- a/src/Splits.sol
+++ b/src/Splits.sol
@@ -16,9 +16,8 @@ struct SplitsReceiver {
 /// It's up to the caller to guarantee that this limit is never exceeded,
 /// failing to do so may result in a total protocol collapse.
 abstract contract Splits {
-    /// @notice Maximum number of splits receivers of a single user.
-    /// Limits cost of collecting.
-    uint32 internal constant _MAX_SPLITS_RECEIVERS = 200;
+    /// @notice Maximum number of splits receivers of a single user. Limits the cost of splitting.
+    uint256 internal constant _MAX_SPLITS_RECEIVERS = 200;
     /// @notice The total splits weight of a user
     uint32 internal constant _TOTAL_SPLITS_WEIGHT = 1_000_000;
     /// @notice The total amount the contract can keep track of each asset.

--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -5,19 +5,19 @@ import {Test} from "forge-std/Test.sol";
 import {Drips, DripsConfig, DripsHistory, DripsConfigImpl, DripsReceiver} from "../Drips.sol";
 
 contract PseudoRandomUtils {
-    bytes32 private salt;
+    bytes32 private seed;
     bool private initialized = false;
 
     // returns a pseudo-random number between 0 and range
     function random(uint256 range) public returns (uint256) {
-        require(initialized, "salt not set for test run");
-        salt = keccak256(bytes.concat(salt));
-        return uint256(salt) % range;
+        require(initialized, "seed not set for test run");
+        seed = keccak256(bytes.concat(seed));
+        return uint256(seed) % range;
     }
 
-    function initSalt(bytes32 salt_) public {
-        require(initialized == false, "only init salt once per test run");
-        salt = salt_;
+    function initSeed(bytes32 seed_) public {
+        require(initialized == false, "only init seed once per test run");
+        seed = seed_;
         initialized = true;
     }
 }
@@ -1371,8 +1371,8 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
         assertBalanceAtReverts(sender, receivers, block.timestamp, ERROR_INVALID_DRIPS_LIST);
     }
 
-    function testFuzzDripsReceiver(bytes32 salt) public {
-        initSalt(salt);
+    function testFuzzDripsReceiver(bytes32 seed) public {
+        initSeed(seed);
         uint8 amountReceivers = 10;
         uint128 maxAmtPerSec = 50;
         uint32 maxDuration = 100;

--- a/src/test/Drips.t.sol
+++ b/src/test/Drips.t.sol
@@ -163,7 +163,7 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
     }
 
     function genRandomRecv(
-        uint8 amountReceiver,
+        uint256 amountReceiver,
         uint128 maxAmtPerSec,
         uint32 maxStart,
         uint32 maxDuration
@@ -177,7 +177,7 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
     }
 
     function genRandomRecv(
-        uint8 amountReceiver,
+        uint256 amountReceiver,
         uint128 maxAmtPerSec,
         uint32 maxStart,
         uint32 maxDuration,
@@ -185,7 +185,7 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
         uint256 probStartNow
     ) internal returns (DripsReceiver[] memory) {
         DripsReceiver[] memory receivers = new DripsReceiver[](amountReceiver);
-        for (uint8 i = 0; i < amountReceiver; i++) {
+        for (uint256 i = 0; i < amountReceiver; i++) {
             uint256 dripId = random(type(uint32).max + uint256(1));
             uint256 amtPerSec = random(maxAmtPerSec) + 1;
             uint256 start = random(maxStart);
@@ -1085,7 +1085,7 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
     }
 
     function testLimitsTheTotalReceiversCount() public {
-        uint160 countMax = Drips._MAX_DRIPS_RECEIVERS;
+        uint256 countMax = Drips._MAX_DRIPS_RECEIVERS;
         DripsReceiver[] memory receivers = new DripsReceiver[](countMax);
         for (uint160 i = 0; i < countMax; i++) {
             receivers[i] = recv(i, 1, 0, 0)[0];
@@ -1098,7 +1098,7 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
     }
 
     function testBenchSetDrips100() public {
-        uint160 countMax = Drips._MAX_DRIPS_RECEIVERS;
+        uint256 countMax = Drips._MAX_DRIPS_RECEIVERS;
         DripsReceiver[] memory receivers = new DripsReceiver[](countMax);
         for (uint160 i = 0; i < countMax; i++) {
             receivers[i] = recv(i, 1, 1000 + i, 0)[0];
@@ -1106,11 +1106,7 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
 
         uint256 gas = gasleft();
         Drips._setDrips(
-            sender,
-            assetId,
-            new DripsReceiver[](0),
-            int128(int160((countMax * countMax))),
-            receivers
+            sender, assetId, new DripsReceiver[](0), int128(int256(countMax * countMax)), receivers
         );
         gas -= gasleft();
         emit log_named_uint("GAS USED", gas);
@@ -1121,7 +1117,7 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
         // Every candidate end time requires iterating over all the receivers to tell that
         // the balance is enough to cover it, but on the highest possible timestamp
         // there isn't enough funds, so we can't skip the whole search.
-        uint160 countMax = Drips._MAX_DRIPS_RECEIVERS;
+        uint256 countMax = Drips._MAX_DRIPS_RECEIVERS;
         DripsReceiver[] memory receivers = new DripsReceiver[](countMax);
         for (uint160 i = 0; i < countMax; i++) {
             receivers[i] = recv(i, 1, 0, 0)[0];

--- a/src/test/Splits.t.sol
+++ b/src/test/Splits.t.sol
@@ -172,10 +172,10 @@ contract SplitsTest is Test, Splits {
     }
 
     function testLimitsTheTotalSplitsReceiversCount() public {
-        uint160 countMax = Splits._MAX_SPLITS_RECEIVERS;
+        uint256 countMax = Splits._MAX_SPLITS_RECEIVERS;
         SplitsReceiver[] memory receiversGood = new SplitsReceiver[](countMax);
         SplitsReceiver[] memory receiversBad = new SplitsReceiver[](countMax + 1);
-        for (uint160 i = 0; i < countMax; i++) {
+        for (uint256 i = 0; i < countMax; i++) {
             receiversGood[i] = SplitsReceiver(i, 1);
             receiversBad[i] = receiversGood[i];
         }


### PR DESCRIPTION
This fits better what these constants define: array lengths, which are uint256 anyway. Also fixes the misuse of the term "salt".