### PR TITLE
Move tests from ./src/test to ./test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: *
+
 install         :  forge_install yarn_install
 forge_install   :; forge install
 yarn_install    :; yarn install

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,6 @@ optimizer_runs = 35_000
 verbosity = 1
 fuzz_runs = 5
 remappings = [
-    'forge-std/=lib/forge-std/src/',
     'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/'
 ]
 [fmt]

--- a/test/AddressDriver.t.sol
+++ b/test/AddressDriver.t.sol
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.17;
 
-import {Caller} from "../Caller.sol";
-import {AddressDriver} from "../AddressDriver.sol";
+import {Caller} from "src/Caller.sol";
+import {AddressDriver} from "src/AddressDriver.sol";
 import {
-    DripsConfigImpl, DripsHub, DripsHistory, DripsReceiver, SplitsReceiver
-} from "../DripsHub.sol";
-import {Reserve} from "../Reserve.sol";
-import {Proxy} from "../Upgradeable.sol";
+    DripsConfigImpl,
+    DripsHub,
+    DripsHistory,
+    DripsReceiver,
+    SplitsReceiver
+} from "src/DripsHub.sol";
+import {Reserve} from "src/Reserve.sol";
+import {Proxy} from "src/Upgradeable.sol";
 import {Test} from "forge-std/Test.sol";
 import {
     IERC20,

--- a/test/Caller.t.sol
+++ b/test/Caller.t.sol
@@ -5,7 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {ERC2771Context} from "openzeppelin-contracts/metatx/ERC2771Context.sol";
 import {Address} from "openzeppelin-contracts/utils/Address.sol";
 import {ECDSA} from "openzeppelin-contracts/utils/cryptography/ECDSA.sol";
-import {Call, Caller} from "../Caller.sol";
+import {Call, Caller} from "src/Caller.sol";
 
 contract CallerTest is Test {
     bytes internal constant ERROR_ZERO_INPUT = "Input is zero";

--- a/test/Drips.t.sol
+++ b/test/Drips.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.17;
 
 import {Test} from "forge-std/Test.sol";
-import {Drips, DripsConfig, DripsHistory, DripsConfigImpl, DripsReceiver} from "../Drips.sol";
+import {Drips, DripsConfig, DripsHistory, DripsConfigImpl, DripsReceiver} from "src/Drips.sol";
 
 contract PseudoRandomUtils {
     bytes32 private seed;

--- a/test/DripsHub.t.sol
+++ b/test/DripsHub.t.sol
@@ -2,10 +2,14 @@
 pragma solidity ^0.8.17;
 
 import {
-    SplitsReceiver, DripsConfigImpl, DripsHub, DripsHistory, DripsReceiver
-} from "../DripsHub.sol";
-import {Reserve} from "../Reserve.sol";
-import {Proxy} from "../Upgradeable.sol";
+    SplitsReceiver,
+    DripsConfigImpl,
+    DripsHub,
+    DripsHistory,
+    DripsReceiver
+} from "src/DripsHub.sol";
+import {Reserve} from "src/Reserve.sol";
+import {Proxy} from "src/Upgradeable.sol";
 import {Test} from "forge-std/Test.sol";
 import {
     IERC20,

--- a/test/ImmutableSplitsDriver.t.sol
+++ b/test/ImmutableSplitsDriver.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.17;
 
-import {ImmutableSplitsDriver, UserMetadata} from "../ImmutableSplitsDriver.sol";
-import {DripsHub, SplitsReceiver} from "../DripsHub.sol";
-import {Reserve} from "../Reserve.sol";
-import {Proxy} from "../Upgradeable.sol";
+import {ImmutableSplitsDriver, UserMetadata} from "src/ImmutableSplitsDriver.sol";
+import {DripsHub, SplitsReceiver} from "src/DripsHub.sol";
+import {Reserve} from "src/Reserve.sol";
+import {Proxy} from "src/Upgradeable.sol";
 import {Test} from "forge-std/Test.sol";
 
 contract ImmutableSplitsDriverTest is Test {

--- a/test/NFTDriver.t.sol
+++ b/test/NFTDriver.t.sol
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.17;
 
-import {Caller} from "../Caller.sol";
-import {NFTDriver} from "../NFTDriver.sol";
+import {Caller} from "src/Caller.sol";
+import {NFTDriver} from "src/NFTDriver.sol";
 import {
-    DripsConfigImpl, DripsHub, DripsHistory, DripsReceiver, SplitsReceiver
-} from "../DripsHub.sol";
-import {Reserve} from "../Reserve.sol";
-import {Proxy} from "../Upgradeable.sol";
+    DripsConfigImpl,
+    DripsHub,
+    DripsHistory,
+    DripsReceiver,
+    SplitsReceiver
+} from "src/DripsHub.sol";
+import {Reserve} from "src/Reserve.sol";
+import {Proxy} from "src/Upgradeable.sol";
 import {Test} from "forge-std/Test.sol";
 import {
     IERC20,

--- a/test/Reserve.t.sol
+++ b/test/Reserve.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.17;
 
 import {Test} from "forge-std/Test.sol";
-import {IReservePlugin, Reserve} from "../Reserve.sol";
+import {IReservePlugin, Reserve} from "src/Reserve.sol";
 import {
     IERC20,
     ERC20PresetFixedSupply

--- a/test/Splits.t.sol
+++ b/test/Splits.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.17;
 
 import {Test} from "forge-std/Test.sol";
-import {Splits, SplitsReceiver} from "../Splits.sol";
+import {Splits, SplitsReceiver} from "src//Splits.sol";
 
 contract SplitsTest is Test, Splits {
     Splits.SplitsStorage internal s;


### PR DESCRIPTION
This makes the project structure follow the Foundry's guidelines and moves tests where the tooling actually expects them to be. This also makes https://github.com/radicle-dev/drips-contracts/issues/187 more feasible because clear, understandable for Foundry separation into the source code and the tests allows working around this issue: https://github.com/crytic/slither/issues/1422.