### PR TITLE
Clean up returned values

### DIFF
--- a/src/AddressDriver.sol
+++ b/src/AddressDriver.sol
@@ -73,7 +73,6 @@ contract AddressDriver is Upgradeable, ERC2771Context {
     /// @param newReceivers The list of the drips receivers of the sender to be set.
     /// Must be sorted by the receivers' addresses, deduplicated and without 0 amtPerSecs.
     /// @param transferTo The address to send funds to in case of decreasing balance
-    /// @return newBalance The new drips balance of the sender.
     /// @return realBalanceDelta The actually applied drips balance change.
     function setDrips(
         IERC20 erc20,
@@ -83,11 +82,11 @@ contract AddressDriver is Upgradeable, ERC2771Context {
         uint32 maxEndTip1,
         uint32 maxEndTip2,
         address transferTo
-    ) public returns (uint128 newBalance, int128 realBalanceDelta) {
+    ) public returns (int128 realBalanceDelta) {
         if (balanceDelta > 0) {
             _transferFromCaller(erc20, uint128(balanceDelta));
         }
-        (newBalance, realBalanceDelta) = dripsHub.setDrips(
+        realBalanceDelta = dripsHub.setDrips(
             callerUserId(), erc20, currReceivers, balanceDelta, newReceivers, maxEndTip1, maxEndTip2
         );
         if (realBalanceDelta < 0) {

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -277,11 +277,13 @@ contract DripsHub is Managed, Drips, Splits {
     /// @param userId The user ID
     /// @param currReceivers The list of the user's current splits receivers.
     /// @param amount The amount being split.
-    /// @return collectableAmt The part of the `amount` left for collection after splitting.
+    /// @return collectableAmt The amount made collectable for the user
+    /// on top of what was collectable before.
+    /// @return splitAmt The amount split to the user's splits receivers
     function splitResult(uint256 userId, SplitsReceiver[] memory currReceivers, uint128 amount)
         public
         view
-        returns (uint128 collectableAmt)
+        returns (uint128 collectableAmt, uint128 splitAmt)
     {
         return Splits._splitResult(userId, currReceivers, amount);
     }

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -396,7 +396,6 @@ contract DripsHub is Managed, Drips, Splits {
     /// Positive to add funds to the drips balance, negative to remove them.
     /// @param newReceivers The list of the drips receivers of the user to be set.
     /// Must be sorted by the receivers' addresses, deduplicated and without 0 amtPerSecs.
-    /// @return newBalance The new drips balance of the user.
     /// @return realBalanceDelta The actually applied drips balance change.
     function setDrips(
         uint256 userId,
@@ -406,16 +405,11 @@ contract DripsHub is Managed, Drips, Splits {
         DripsReceiver[] memory newReceivers,
         uint32 maxEndTip1,
         uint32 maxEndTip2
-    )
-        public
-        whenNotPaused
-        onlyDriver(userId)
-        returns (uint128 newBalance, int128 realBalanceDelta)
-    {
+    ) public whenNotPaused onlyDriver(userId) returns (int128 realBalanceDelta) {
         if (balanceDelta > 0) {
             _increaseTotalBalance(erc20, uint128(balanceDelta));
         }
-        (newBalance, realBalanceDelta) = Drips._setDrips(
+        (, realBalanceDelta) = Drips._setDrips(
             userId,
             _assetId(erc20),
             currReceivers,

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -188,14 +188,12 @@ contract DripsHub is Managed, Drips, Splits {
     /// If too low, receiving will be cheap, but may not cover many cycles.
     /// If too high, receiving may become too expensive to fit in a single transaction.
     /// @return receivableAmt The amount which would be received
-    /// @return receivableCycles The number of cycles which would still be receivable after the call
     function receiveDripsResult(uint256 userId, IERC20 erc20, uint32 maxCycles)
         public
         view
-        returns (uint128 receivableAmt, uint32 receivableCycles)
+        returns (uint128 receivableAmt)
     {
-        (receivableAmt, receivableCycles,,,) =
-            Drips._receiveDripsResult(userId, _assetId(erc20), maxCycles);
+        (receivableAmt,,,,) = Drips._receiveDripsResult(userId, _assetId(erc20), maxCycles);
     }
 
     /// @notice Receive drips for the user.
@@ -207,14 +205,13 @@ contract DripsHub is Managed, Drips, Splits {
     /// If too low, receiving will be cheap, but may not cover many cycles.
     /// If too high, receiving may become too expensive to fit in a single transaction.
     /// @return receivedAmt The received amount
-    /// @return receivableCycles The number of cycles which still can be received
     function receiveDrips(uint256 userId, IERC20 erc20, uint32 maxCycles)
         public
         whenNotPaused
-        returns (uint128 receivedAmt, uint32 receivableCycles)
+        returns (uint128 receivedAmt)
     {
         uint256 assetId = _assetId(erc20);
-        (receivedAmt, receivableCycles) = Drips._receiveDrips(userId, assetId, maxCycles);
+        (receivedAmt,) = Drips._receiveDrips(userId, assetId, maxCycles);
         if (receivedAmt > 0) {
             Splits._give(userId, userId, assetId, receivedAmt);
         }

--- a/src/NFTDriver.sol
+++ b/src/NFTDriver.sol
@@ -122,7 +122,6 @@ contract NFTDriver is ERC721Burnable, ERC2771Context, Upgradeable {
     /// @param newReceivers The list of the drips receivers of the sender to be set.
     /// Must be sorted by the receivers' addresses, deduplicated and without 0 amtPerSecs.
     /// @param transferTo The address to send funds to in case of decreasing balance
-    /// @return newBalance The new drips balance of the sender.
     /// @return realBalanceDelta The actually applied drips balance change.
     function setDrips(
         uint256 tokenId,
@@ -133,11 +132,11 @@ contract NFTDriver is ERC721Burnable, ERC2771Context, Upgradeable {
         uint32 maxEndTip1,
         uint32 maxEndTip2,
         address transferTo
-    ) public onlyHolder(tokenId) returns (uint128 newBalance, int128 realBalanceDelta) {
+    ) public onlyHolder(tokenId) returns (int128 realBalanceDelta) {
         if (balanceDelta > 0) {
             _transferFromCaller(erc20, uint128(balanceDelta));
         }
-        (newBalance, realBalanceDelta) = dripsHub.setDrips(
+        realBalanceDelta = dripsHub.setDrips(
             tokenId, erc20, currReceivers, balanceDelta, newReceivers, maxEndTip1, maxEndTip2
         );
         if (realBalanceDelta < 0) {

--- a/src/Splits.sol
+++ b/src/Splits.sol
@@ -106,22 +106,24 @@ abstract contract Splits {
     /// @param userId The user ID
     /// @param currReceivers The list of the user's current splits receivers.
     /// @param amount The amount being split.
-    /// @return collectableAmt The part of the `amount` left for collection after splitting.
+    /// @return collectableAmt The amount made collectable for the user
+    /// on top of what was collectable before.
+    /// @return splitAmt The amount split to the user's splits receivers
     function _splitResult(uint256 userId, SplitsReceiver[] memory currReceivers, uint128 amount)
         internal
         view
-        returns (uint128 collectableAmt)
+        returns (uint128 collectableAmt, uint128 splitAmt)
     {
         _assertCurrSplits(userId, currReceivers);
         if (amount == 0) {
-            return 0;
+            return (0, 0);
         }
         uint32 splitsWeight = 0;
         for (uint256 i = 0; i < currReceivers.length; i++) {
             splitsWeight += currReceivers[i].weight;
         }
-        uint128 splitAmt = uint128((uint160(amount) * splitsWeight) / _TOTAL_SPLITS_WEIGHT);
-        return amount - splitAmt;
+        splitAmt = uint128((uint160(amount) * splitsWeight) / _TOTAL_SPLITS_WEIGHT);
+        collectableAmt = amount - splitAmt;
     }
 
     /// @notice Splits user's received but not split yet funds among receivers.

--- a/test/AddressDriver.t.sol
+++ b/test/AddressDriver.t.sol
@@ -100,12 +100,13 @@ contract AddressDriverTest is Test {
         receivers[0] = DripsReceiver(userId, DripsConfigImpl.create(0, 1, 0, 0));
         uint256 balance = erc20.balanceOf(address(this));
 
-        (uint128 newBalance, int128 realBalanceDelta) = driver.setDrips(
+        int128 realBalanceDelta = driver.setDrips(
             erc20, new DripsReceiver[](0), int128(amt), receivers, 0, 0, address(this)
         );
 
         assertEq(erc20.balanceOf(address(this)), balance - amt, "Invalid balance after top-up");
-        assertEq(newBalance, amt, "Invalid drips balance after top-up");
+        (,,, uint128 dripsBalance,) = dripsHub.dripsState(thisId, erc20);
+        assertEq(dripsBalance, amt, "Invalid drips balance after top-up");
         assertEq(realBalanceDelta, int128(amt), "Invalid drips balance delta after top-up");
         (bytes32 dripsHash,,,,) = dripsHub.dripsState(thisId, erc20);
         assertEq(dripsHash, dripsHub.hashDrips(receivers), "Invalid drips hash after top-up");
@@ -113,11 +114,12 @@ contract AddressDriverTest is Test {
         // Withdraw
         balance = erc20.balanceOf(address(user));
 
-        (newBalance, realBalanceDelta) =
+        realBalanceDelta =
             driver.setDrips(erc20, receivers, -int128(amt), receivers, 0, 0, address(user));
 
         assertEq(erc20.balanceOf(address(user)), balance + amt, "Invalid balance after withdrawal");
-        assertEq(newBalance, 0, "Invalid drips balance after withdrawal");
+        (,,, dripsBalance,) = dripsHub.dripsState(thisId, erc20);
+        assertEq(dripsBalance, 0, "Invalid drips balance after withdrawal");
         assertEq(realBalanceDelta, -int128(amt), "Invalid drips balance delta after withdrawal");
     }
 
@@ -127,11 +129,12 @@ contract AddressDriverTest is Test {
         driver.setDrips(erc20, receivers, int128(amt), receivers, 0, 0, address(this));
         address transferTo = address(1234);
 
-        (uint128 newBalance, int128 realBalanceDelta) =
+        int128 realBalanceDelta =
             driver.setDrips(erc20, receivers, -int128(amt), receivers, 0, 0, transferTo);
 
         assertEq(erc20.balanceOf(transferTo), amt, "Invalid balance");
-        assertEq(newBalance, 0, "Invalid drips balance");
+        (,,, uint128 dripsBalance,) = dripsHub.dripsState(thisId, erc20);
+        assertEq(dripsBalance, 0, "Invalid drips balance");
         assertEq(realBalanceDelta, -int128(amt), "Invalid drips balance delta");
     }
 

--- a/test/DripsHub.t.sol
+++ b/test/DripsHub.t.sol
@@ -276,11 +276,10 @@ contract DripsHubTest is Test {
     function collectAll(uint256 forUser, uint128 expectedCollected, uint128 expectedSplit)
         internal
     {
-        (uint128 receivable,) = dripsHub.receiveDripsResult(forUser, erc20, type(uint32).max);
-        (uint128 received, uint32 receivableCycles) =
-            dripsHub.receiveDrips(forUser, erc20, type(uint32).max);
+        uint128 receivable = dripsHub.receiveDripsResult(forUser, erc20, type(uint32).max);
+        uint128 received = dripsHub.receiveDrips(forUser, erc20, type(uint32).max);
         assertEq(received, receivable, "Invalid received amount");
-        assertEq(receivableCycles, 0, "Non-zero receivable cycles");
+        assertReceivableDripsCycles(forUser, 0);
 
         split(forUser, expectedCollected - collectable(forUser), expectedSplit);
 
@@ -306,16 +305,14 @@ contract DripsHubTest is Test {
         uint128 expectedTotalAmt = expectedReceivedAmt + expectedAmtAfter;
         uint32 expectedTotalCycles = expectedReceivedCycles + expectedCyclesAfter;
         assertReceivableDripsCycles(forUser, expectedTotalCycles);
-        assertReceiveDripsResult(forUser, type(uint32).max, expectedTotalAmt, 0);
-        assertReceiveDripsResult(forUser, maxCycles, expectedReceivedAmt, expectedCyclesAfter);
+        assertReceiveDripsResult(forUser, type(uint32).max, expectedTotalAmt);
+        assertReceiveDripsResult(forUser, maxCycles, expectedReceivedAmt);
 
-        (uint128 receivedAmt, uint32 receivableCycles) =
-            dripsHub.receiveDrips(forUser, erc20, maxCycles);
+        uint128 receivedAmt = dripsHub.receiveDrips(forUser, erc20, maxCycles);
 
         assertEq(receivedAmt, expectedReceivedAmt, "Invalid amount received from drips");
-        assertEq(receivableCycles, expectedCyclesAfter, "Invalid receivable drips cycles left");
         assertReceivableDripsCycles(forUser, expectedCyclesAfter);
-        assertReceiveDripsResult(forUser, type(uint32).max, expectedAmtAfter, 0);
+        assertReceiveDripsResult(forUser, type(uint32).max, expectedAmtAfter);
     }
 
     function assertReceivableDripsCycles(uint256 forUser, uint32 expectedCycles) internal {
@@ -323,16 +320,11 @@ contract DripsHubTest is Test {
         assertEq(actualCycles, expectedCycles, "Invalid total receivable drips cycles");
     }
 
-    function assertReceiveDripsResult(
-        uint256 forUser,
-        uint32 maxCycles,
-        uint128 expectedAmt,
-        uint32 expectedCycles
-    ) internal {
-        (uint128 actualAmt, uint32 actualCycles) =
-            dripsHub.receiveDripsResult(forUser, erc20, maxCycles);
+    function assertReceiveDripsResult(uint256 forUser, uint32 maxCycles, uint128 expectedAmt)
+        internal
+    {
+        uint128 actualAmt = dripsHub.receiveDripsResult(forUser, erc20, maxCycles);
         assertEq(actualAmt, expectedAmt, "Invalid receivable amount");
-        assertEq(actualCycles, expectedCycles, "Invalid receivable drips cycles");
     }
 
     function split(uint256 forUser, uint128 expectedCollectable, uint128 expectedSplit) internal {

--- a/test/DripsHub.t.sol
+++ b/test/DripsHub.t.sol
@@ -351,9 +351,10 @@ contract DripsHubTest is Test {
     }
 
     function assertSplitResult(uint256 forUser, uint256 amt, uint256 expected) internal {
-        uint128 actual =
+        (uint128 collectableAmt, uint128 splitAmt) =
             dripsHub.splitResult(forUser, getCurrSplitsReceivers(forUser), uint128(amt));
-        assertEq(actual, expected, "Invalid split result");
+        assertEq(collectableAmt, expected, "Invalid collectable amount");
+        assertEq(splitAmt, amt - expected, "Invalid split amount");
     }
 
     function collect(uint256 forUser, uint128 expectedAmt) internal {

--- a/test/DripsHub.t.sol
+++ b/test/DripsHub.t.sol
@@ -145,11 +145,11 @@ contract DripsHubTest is Test {
         DripsReceiver[] memory currReceivers = loadDrips(forUser);
 
         vm.prank(driver);
-        (uint128 newBalance, int128 realBalanceDelta) =
+        int128 realBalanceDelta =
             dripsHub.setDrips(forUser, erc20, currReceivers, balanceDelta, newReceivers, 0, 0);
 
         storeDrips(forUser, newReceivers);
-        assertEq(newBalance, balanceTo, "Invalid drips balance");
+        assertDripsBalance(forUser, balanceTo);
         assertEq(realBalanceDelta, balanceDelta, "Invalid real balance delta");
         (,, uint32 updateTime, uint128 actualBalance,) = dripsHub.dripsState(forUser, erc20);
         assertEq(updateTime, block.timestamp, "Invalid new last update time");

--- a/test/NFTDriver.t.sol
+++ b/test/NFTDriver.t.sol
@@ -151,12 +151,14 @@ contract NFTDriverTest is Test {
         receivers[0] = DripsReceiver(tokenId2, DripsConfigImpl.create(0, 1, 0, 0));
         uint256 balance = erc20.balanceOf(address(this));
 
-        (uint128 newBalance, int128 realBalanceDelta) = driver.setDrips(
+        int128 realBalanceDelta = driver.setDrips(
             tokenId1, erc20, new DripsReceiver[](0), int128(amt), receivers, 0, 0, address(this)
         );
 
         assertEq(erc20.balanceOf(address(this)), balance - amt, "Invalid balance after top-up");
-        assertEq(newBalance, amt, "Invalid drips balance after top-up");
+        (,,, uint128 dripsBalance,) = dripsHub.dripsState(tokenId1, erc20);
+        assertEq(dripsBalance, amt, "Invalid drips balance after top-up");
+
         assertEq(realBalanceDelta, int128(amt), "Invalid drips balance delta after top-up");
         (bytes32 dripsHash,,,,) = dripsHub.dripsState(tokenId1, erc20);
         assertEq(dripsHash, dripsHub.hashDrips(receivers), "Invalid drips hash after top-up");
@@ -164,12 +166,13 @@ contract NFTDriverTest is Test {
         // Withdraw
         balance = erc20.balanceOf(address(user));
 
-        (newBalance, realBalanceDelta) = driver.setDrips(
+        realBalanceDelta = driver.setDrips(
             tokenId1, erc20, receivers, -int128(amt), receivers, 0, 0, address(user)
         );
 
         assertEq(erc20.balanceOf(address(user)), balance + amt, "Invalid balance after withdrawal");
-        assertEq(newBalance, 0, "Invalid drips balance after withdrawal");
+        (,,, dripsBalance,) = dripsHub.dripsState(tokenId1, erc20);
+        assertEq(dripsBalance, 0, "Invalid drips balance after withdrawal");
         assertEq(realBalanceDelta, -int128(amt), "Invalid drips balance delta after withdrawal");
     }
 
@@ -179,11 +182,13 @@ contract NFTDriverTest is Test {
         driver.setDrips(tokenId, erc20, receivers, int128(amt), receivers, 0, 0, address(this));
         address transferTo = address(1234);
 
-        (uint128 newBalance, int128 realBalanceDelta) =
+        int128 realBalanceDelta =
             driver.setDrips(tokenId, erc20, receivers, -int128(amt), receivers, 0, 0, transferTo);
 
         assertEq(erc20.balanceOf(transferTo), amt, "Invalid balance");
-        assertEq(newBalance, 0, "Invalid drips balance");
+
+        (,,, uint128 dripsBalance,) = dripsHub.dripsState(tokenId1, erc20);
+        assertEq(dripsBalance, 0, "Invalid drips balance");
         assertEq(realBalanceDelta, -int128(amt), "Invalid drips balance delta");
     }
 

--- a/test/Splits.t.sol
+++ b/test/Splits.t.sol
@@ -112,12 +112,22 @@ contract SplitsTest is Test, Splits {
         uint128 expectedCollectable,
         uint128 expectedSplit
     ) internal {
-        (uint128 collectableAmt, uint128 splitAmt) =
-            Splits._split(userId, asset, getCurrSplitsReceivers(userId));
+        uint128 collectableBefore = Splits._collectable(userId, asset);
+        SplitsReceiver[] memory receivers = getCurrSplitsReceivers(userId);
+        uint128 amt = Splits._splittable(userId, asset);
+        (uint128 collectableRes, uint128 splitRes) = Splits._splitResult(userId, receivers, amt);
 
+        (uint128 collectableAmt, uint128 splitAmt) = Splits._split(userId, asset, receivers);
+
+        assertEq(collectableRes, collectableAmt, "Invalid result collectable amount");
         assertEq(collectableAmt, expectedCollectable, "Invalid collectable amount");
-        assertEq(Splits._collectable(userId, asset), collectableAmt);
+        assertEq(
+            collectableBefore + collectableAmt,
+            Splits._collectable(userId, asset),
+            "Invalid collectable after splitting"
+        );
         assertEq(splitAmt, expectedSplit, "Invalid split amount");
+        assertEq(splitRes, splitAmt, "Invalid result split amount");
         assertSplittable(userId, 0);
     }
 


### PR DESCRIPTION
The changes:
- `receiveDrips`, `receiveDripsResult` - stop returning `receivableCycles`, because it's easily accessible via `receivableDripsCycles`.
- `splitResults` - return `splitAmt` to consistently match `split` API, even though `splitAmt` could be calculated as `amount - collectableAmt`, but that's confusing.
- `setDrips` - stop returning `newBalance`, because it's easily accessible via `dripsState` along the rest of the state.