### PR TITLE
Clean up Drips API

### DIFF
--- a/src/Drips.sol
+++ b/src/Drips.sol
@@ -221,11 +221,11 @@ abstract contract Drips {
     /// If too low, receiving will be cheap, but may not cover many cycles.
     /// If too high, receiving may become too expensive to fit in a single transaction.
     /// @return receivedAmt The received amount
-    /// @return receivableCycles The number of cycles which still can be received
     function _receiveDrips(uint256 userId, uint256 assetId, uint32 maxCycles)
         internal
-        returns (uint128 receivedAmt, uint32 receivableCycles)
+        returns (uint128 receivedAmt)
     {
+        uint32 receivableCycles;
         uint32 fromCycle;
         uint32 toCycle;
         int128 finalAmtPerCycle;

--- a/src/Drips.sol
+++ b/src/Drips.sol
@@ -605,7 +605,7 @@ abstract contract Drips {
         DripsReceiver[] memory receivers,
         uint32 maxEndTip1,
         uint32 maxEndTip2
-    ) internal view returns (uint32 maxEnd) {
+    ) private view returns (uint32 maxEnd) {
         require(receivers.length <= _MAX_DRIPS_RECEIVERS, "Too many drips receivers");
         uint256[] memory configs = new uint256[](receivers.length);
         uint256 configsLen = 0;

--- a/src/Drips.sol
+++ b/src/Drips.sol
@@ -537,7 +537,6 @@ abstract contract Drips {
     /// Positive when adding funds to the drips balance, negative to removing them.
     /// @param newReceivers The list of the drips receivers of the user to be set.
     /// Must be sorted, deduplicated and without 0 amtPerSecs.
-    /// @return newBalance The new drips balance of the user.
     /// @return realBalanceDelta The actually applied drips balance change.
     function _setDrips(
         uint256 userId,
@@ -547,10 +546,11 @@ abstract contract Drips {
         DripsReceiver[] memory newReceivers,
         uint32 maxEndTip1,
         uint32 maxEndTip2
-    ) internal returns (uint128 newBalance, int128 realBalanceDelta) {
+    ) internal returns (int128 realBalanceDelta) {
         DripsState storage state = _dripsStorage().states[assetId][userId];
         require(_hashDrips(currReceivers) == state.dripsHash, "Invalid current drips list");
         uint32 lastUpdate = state.updateTime;
+        uint128 newBalance;
         uint32 newMaxEnd;
         {
             uint32 currMaxEnd = state.maxEnd;

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -241,7 +241,7 @@ contract DripsHub is Managed, Drips, Splits {
         returns (uint128 receivedAmt)
     {
         uint256 assetId = _assetId(erc20);
-        (receivedAmt,) = Drips._receiveDrips(userId, assetId, maxCycles);
+        receivedAmt = Drips._receiveDrips(userId, assetId, maxCycles);
         if (receivedAmt > 0) {
             Splits._give(userId, userId, assetId, receivedAmt);
         }

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -489,7 +489,7 @@ contract DripsHub is Managed, Drips, Splits {
         if (balanceDelta > 0) {
             _increaseTotalBalance(erc20, uint128(balanceDelta));
         }
-        (, realBalanceDelta) = Drips._setDrips(
+        realBalanceDelta = Drips._setDrips(
             userId,
             _assetId(erc20),
             currReceivers,

--- a/test/Drips.t.sol
+++ b/test/Drips.t.sol
@@ -381,7 +381,7 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
     }
 
     function receiveDrips(uint256 userId, uint128 expectedAmt) internal {
-        (uint128 actualAmt,) = Drips._receiveDrips(userId, assetId, type(uint32).max);
+        uint128 actualAmt = Drips._receiveDrips(userId, assetId, type(uint32).max);
         assertEq(actualAmt, expectedAmt, "Invalid amount received from drips");
     }
 
@@ -399,11 +399,9 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
         assertReceiveDripsResult(userId, type(uint32).max, expectedTotalAmt, 0);
         assertReceiveDripsResult(userId, maxCycles, expectedReceivedAmt, expectedCyclesAfter);
 
-        (uint128 receivedAmt, uint32 receivableCycles) =
-            Drips._receiveDrips(userId, assetId, maxCycles);
+        uint128 receivedAmt = Drips._receiveDrips(userId, assetId, maxCycles);
 
         assertEq(receivedAmt, expectedReceivedAmt, "Invalid amount received from drips");
-        assertEq(receivableCycles, expectedCyclesAfter, "Invalid receivable drips cycles left");
         assertReceivableDripsCycles(userId, expectedCyclesAfter);
         assertReceiveDripsResult(userId, type(uint32).max, expectedAmtAfter, 0);
     }
@@ -430,7 +428,7 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
             }
 
             uint256 expectedAmt = (duration * r.config.amtPerSec()) >> 64;
-            (uint128 actualAmt,) = Drips._receiveDrips(r.userId, assetId, type(uint32).max);
+            uint128 actualAmt = Drips._receiveDrips(r.userId, assetId, type(uint32).max);
             // only log if acutalAmt doesn't match exptectedAmt
             if (expectedAmt != actualAmt) {
                 emit log_named_uint("userId:", r.userId);

--- a/test/Drips.t.sol
+++ b/test/Drips.t.sol
@@ -272,12 +272,11 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
         (, bytes32 oldHistoryHash,,,) = Drips._dripsState(userId, assetId);
         int128 balanceDelta = int128(balanceTo) - int128(balanceFrom);
 
-        (uint128 newBalance, int128 realBalanceDelta) = Drips._setDrips(
+        int128 realBalanceDelta = Drips._setDrips(
             userId, assetId, loadCurrReceivers(userId), balanceDelta, newReceivers, 0, 0
         );
 
         storeCurrReceivers(userId, newReceivers);
-        assertEq(newBalance, balanceTo, "Invalid drips balance");
         (
             bytes32 dripsHash,
             bytes32 historyHash,
@@ -1245,10 +1244,10 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
         // Sender had 4 second paying 1 per second
 
         DripsReceiver[] memory newRecv = recv();
-        (uint128 newBalance, int128 realBalanceDelta) =
+        int128 realBalanceDelta =
             Drips._setDrips(sender, assetId, receivers, type(int128).min, newRecv, 0, 0);
         storeCurrReceivers(sender, newRecv);
-        assertEq(newBalance, 0, "Invalid balance");
+        assertBalance(sender, 0);
         assertEq(realBalanceDelta, -6, "Invalid real balance delta");
         assertBalance(sender, 0);
         skipToCycleEnd();

--- a/test/Drips.t.sol
+++ b/test/Drips.t.sol
@@ -301,6 +301,11 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
         assertEq(actual, expected, "Invalid drips configuration");
     }
 
+    function assertMaxEnd(uint256 userId, uint256 expected) internal {
+        (,,,, uint32 actual) = Drips._dripsState(userId, assetId);
+        assertEq(actual, expected, "Invalid max end");
+    }
+
     function assertBalance(uint256 userId, uint128 expected) internal {
         assertBalanceAt(userId, expected, block.timestamp);
     }
@@ -1407,7 +1412,8 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
         );
 
         skipTo(0);
-        assertEq(Drips._calcMaxEnd(100, receivers, 0, type(uint32).max), 75);
+        setDrips(sender, 0, 100, receivers);
+        assertMaxEnd(sender, 75);
     }
 
     function testReceiverMaxEndExampleB() public {
@@ -1418,7 +1424,8 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
 
         // in the past
         skipTo(70);
-        assertEq(Drips._calcMaxEnd(100, receivers, 0, type(uint32).max), 130);
+        setDrips(sender, 0, 100, receivers);
+        assertMaxEnd(sender, 130);
     }
 
     function _receiverMaxEndEdgeCase(uint128 balance) internal {
@@ -1427,7 +1434,8 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
             recv({userId: receiver2, amtPerSec: 1, start: 2, duration: 0})
         );
         skipTo(0);
-        assertEq(Drips._calcMaxEnd(balance, receivers, 0, type(uint32).max), 3);
+        setDrips(sender, 0, balance, receivers);
+        assertMaxEnd(sender, 3);
     }
 
     function testReceiverMaxEndEdgeCase() public {
@@ -1444,7 +1452,8 @@ contract DripsTest is Test, PseudoRandomUtils, Drips {
             recv({userId: receiver2, amtPerSec: 1, start: 1000, duration: 0})
         );
         skipTo(0);
-        assertEq(Drips._calcMaxEnd(100, receivers, 0, type(uint32).max), 150);
+        setDrips(sender, 0, 100, receivers);
+        assertMaxEnd(sender, 150);
     }
 
     function testSqueezeDrips() public {


### PR DESCRIPTION
Clean up the internal API. Remove return values not used in DripsHub and make `_calcMaxEnd` private.