### PR TITLE
Add drips balance fuzz tests

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -8,3 +8,5 @@ remappings = [
 ]
 [fmt]
 line_length = 100
+[fuzz]
+runs = 4


### PR DESCRIPTION
Also extend and clean up tests with overlapping cases due to `setDrips` verifying `maxEnd`.