### PR TITLE
Typo Fixed

### DIFF
--- a/test/Splits.t.sol
+++ b/test/Splits.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.17;
 
 import {Test} from "forge-std/Test.sol";
-import {Splits, SplitsReceiver} from "src//Splits.sol";
+import {Splits, SplitsReceiver} from "src/Splits.sol";
 
 contract SplitsTest is Test, Splits {
     Splits.SplitsStorage internal s;


### PR DESCRIPTION
There is a typo in [splits.t.sol](https://github.com/radicle-dev/drips-contracts/blob/aa149127572e467af4c1adf4c2a37160b39bc91b/test/Splits.t.sol#L5).

Splits.sol tests are not running because of this typo.

Changed `import {Splits, SplitsReceiver} from "src//Splits.sol";` --> `import {Splits, SplitsReceiver} from "src/Splits.sol";`

Thanks,
DevABDee.