### PR TITLE
Fix NFTDriver token metadata

### DIFF
--- a/src/NFTDriver.sol
+++ b/src/NFTDriver.sol
@@ -9,7 +9,8 @@ import {StorageSlot} from "openzeppelin-contracts/utils/StorageSlot.sol";
 import {
     ERC721,
     ERC721Burnable,
-    IERC721
+    IERC721,
+    IERC721Metadata
 } from "openzeppelin-contracts/token/ERC721/extensions/ERC721Burnable.sol";
 
 /// @notice A DripsHub driver implementing token-based user identification.
@@ -31,7 +32,7 @@ contract NFTDriver is ERC721Burnable, ERC2771Context, Managed {
     /// @param _driverId The driver ID to use when calling DripsHub.
     constructor(DripsHub _dripsHub, address forwarder, uint32 _driverId)
         ERC2771Context(forwarder)
-        ERC721("DripsHub identity", "DHI")
+        ERC721("", "")
     {
         dripsHub = _dripsHub;
         driverId = _driverId;
@@ -238,6 +239,16 @@ contract NFTDriver is ERC721Burnable, ERC2771Context, Managed {
         onlyHolder(tokenId)
     {
         dripsHub.emitUserMetadata(tokenId, userMetadata);
+    }
+
+    /// @inheritdoc IERC721Metadata
+    function name() public pure override returns (string memory) {
+        return "DripsHub identity";
+    }
+
+    /// @inheritdoc IERC721Metadata
+    function symbol() public pure override returns (string memory) {
+        return "DHI";
     }
 
     /// @inheritdoc ERC721Burnable

--- a/test/NFTDriver.t.sol
+++ b/test/NFTDriver.t.sol
@@ -60,6 +60,14 @@ contract NFTDriverTest is Test {
         erc20.approve(address(driver), type(uint256).max);
     }
 
+    function testName() public {
+        assertEq(driver.name(), "DripsHub identity", "Invalid token name");
+    }
+
+    function testSymbol() public {
+        assertEq(driver.symbol(), "DHI", "Invalid token symbol");
+    }
+
     function testApproveLetsUseIdentity() public {
         vm.prank(user);
         driver.approve(address(this), tokenIdUser);


### PR DESCRIPTION
OZ stores name and symbol in storage initialized in constructor. Putting the token contract behind a proxy replaces storage with an empty one clearing the token metadata.