### PR TITLE
Ban registering drivers for 0 address

### DIFF
--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -142,11 +142,12 @@ contract DripsHub is Managed, Drips, Splits {
     /// That range consists of all 2^224 user IDs with highest 32 bits equal to the driver ID.
     /// Every driver ID is assigned only to a single address,
     /// but a single address can have multiple driver IDs assigned to it.
-    /// @param driverAddr The address of the driver.
+    /// @param driverAddr The address of the driver. Must not be zero address.
     /// It should be a smart contract capable of dealing with the DripsHub API.
     /// It shouldn't be an EOA because the API requires making multiple calls per transaction.
     /// @return driverId The registered driver ID.
     function registerDriver(address driverAddr) public whenNotPaused returns (uint32 driverId) {
+        require(driverAddr != address(0), "Driver registered for 0 address");
         DripsHubStorage storage dripsHubStorage = _dripsHubStorage();
         driverId = dripsHubStorage.nextDriverId++;
         dripsHubStorage.driverAddresses[driverId] = driverAddr;

--- a/test/AddressDriver.t.sol
+++ b/test/AddressDriver.t.sol
@@ -36,8 +36,8 @@ contract AddressDriverTest is Test {
         caller = new Caller();
 
         // Make AddressDriver's driver ID non-0 to test if it's respected by AddressDriver
-        dripsHub.registerDriver(address(0));
-        dripsHub.registerDriver(address(0));
+        dripsHub.registerDriver(address(1));
+        dripsHub.registerDriver(address(1));
         uint32 driverId = dripsHub.registerDriver(address(this));
         AddressDriver driverLogic = new AddressDriver(dripsHub, address(caller), driverId);
         driver = AddressDriver(address(new ManagedProxy(driverLogic, admin)));

--- a/test/DripsHub.t.sol
+++ b/test/DripsHub.t.sol
@@ -535,6 +535,11 @@ contract DripsHubTest is Test {
         assertEq(nextDriverId + 1, dripsHub.nextDriverId(), "Invalid next driver ID");
     }
 
+    function testRegisteringDriverForZeroAddressReverts() public {
+        vm.expectRevert("Driver registered for 0 address");
+        dripsHub.registerDriver(address(0));
+    }
+
     function testUpdateDriverAddress() public {
         assertEq(driver, dripsHub.driverAddress(driverId), "Invalid driver address before");
         address newDriverAddr = address(0x1234);

--- a/test/ImmutableSplitsDriver.t.sol
+++ b/test/ImmutableSplitsDriver.t.sol
@@ -17,8 +17,8 @@ contract ImmutableSplitsDriverTest is Test {
         dripsHub = DripsHub(address(new ManagedProxy(hubLogic, address(this))));
 
         // Make the driver ID non-0 to test if it's respected by the driver
-        dripsHub.registerDriver(address(0));
-        dripsHub.registerDriver(address(0));
+        dripsHub.registerDriver(address(1));
+        dripsHub.registerDriver(address(1));
         uint32 driverId = dripsHub.registerDriver(address(this));
         ImmutableSplitsDriver driverLogic = new ImmutableSplitsDriver(dripsHub, driverId);
         driver = ImmutableSplitsDriver(address(new ManagedProxy(driverLogic, admin)));

--- a/test/NFTDriver.t.sol
+++ b/test/NFTDriver.t.sol
@@ -41,8 +41,8 @@ contract NFTDriverTest is Test {
         caller = new Caller();
 
         // Make NFTDriver's driver ID non-0 to test if it's respected by NFTDriver
-        dripsHub.registerDriver(address(0));
-        dripsHub.registerDriver(address(0));
+        dripsHub.registerDriver(address(1));
+        dripsHub.registerDriver(address(1));
         uint32 driverId = dripsHub.registerDriver(address(this));
         NFTDriver driverLogic = new NFTDriver(dripsHub, address(caller), driverId);
         driver = NFTDriver(address(new ManagedProxy(driverLogic, admin)));


### PR DESCRIPTION
This makes the theoretical attack of draining all driver IDs 4 times slower. Plus it never made sense to register drivers on address `0`.