### PR TITLE
Shorten error messages

### DIFF
--- a/src/Drips.sol
+++ b/src/Drips.sol
@@ -459,7 +459,7 @@ abstract contract Drips {
             DripsHistory memory drips = dripsHistory[i];
             bytes32 dripsHash = drips.dripsHash;
             if (drips.receivers.length != 0) {
-                require(dripsHash == 0, "Drips history entry with hash and receivers");
+                require(dripsHash == 0, "Entry with hash and receivers");
                 dripsHash = _hashDrips(drips.receivers);
             }
             historyHashes[i] = historyHash;
@@ -546,7 +546,7 @@ abstract contract Drips {
         uint32 timestamp
     ) internal view returns (uint128 balance) {
         DripsState storage state = _dripsStorage().states[assetId][userId];
-        require(timestamp >= state.updateTime, "Timestamp before last drips update");
+        require(timestamp >= state.updateTime, "Timestamp before the last update");
         _verifyDripsReceivers(currReceivers, state);
         return _calcBalance(state.balance, state.updateTime, state.maxEnd, currReceivers, timestamp);
     }
@@ -795,7 +795,7 @@ abstract contract Drips {
             for (uint256 i = 0; i < receivers.length; i++) {
                 DripsReceiver memory receiver = receivers[i];
                 if (i > 0) {
-                    require(_isOrdered(receivers[i - 1], receiver), "Receivers not sorted");
+                    require(_isOrdered(receivers[i - 1], receiver), "Drips receivers not sorted");
                 }
                 configsLen = _addConfig(configs, configsLen, receiver);
             }

--- a/src/Managed.sol
+++ b/src/Managed.sol
@@ -43,15 +43,13 @@ abstract contract Managed is UUPSUpgradeable {
 
     /// @notice Throws if called by any caller other than the admin.
     modifier onlyAdmin() {
-        require(admin() == msg.sender, "Caller is not the admin");
+        require(admin() == msg.sender, "Caller not the admin");
         _;
     }
 
     /// @notice Throws if called by any caller other than the admin or a pauser.
     modifier onlyAdminOrPauser() {
-        require(
-            admin() == msg.sender || isPauser(msg.sender), "Caller is not the admin or a pauser"
-        );
+        require(admin() == msg.sender || isPauser(msg.sender), "Caller not the admin or a pauser");
         _;
     }
 

--- a/src/Splits.sol
+++ b/src/Splits.sol
@@ -243,8 +243,7 @@ abstract contract Splits {
             totalWeight += weight;
             uint256 userId = receiver.userId;
             if (i > 0) {
-                require(prevUserId != userId, "Duplicate splits receivers");
-                require(prevUserId < userId, "Splits receivers not sorted by user ID");
+                require(prevUserId < userId, "Splits receivers not sorted");
             }
             prevUserId = userId;
             emit SplitsReceiverSeen(receiversHash, userId, weight);

--- a/test/Drips.t.sol
+++ b/test/Drips.t.sol
@@ -31,11 +31,11 @@ contract AssertMinAmtPerSec is Test, Drips {
 }
 
 contract DripsTest is Test, PseudoRandomUtils, Drips {
-    bytes internal constant ERROR_NOT_SORTED = "Receivers not sorted";
+    bytes internal constant ERROR_NOT_SORTED = "Drips receivers not sorted";
     bytes internal constant ERROR_INVALID_DRIPS_LIST = "Invalid current drips list";
-    bytes internal constant ERROR_TIMESTAMP_EARLY = "Timestamp before last drips update";
+    bytes internal constant ERROR_TIMESTAMP_EARLY = "Timestamp before the last update";
     bytes internal constant ERROR_HISTORY_INVALID = "Invalid drips history";
-    bytes internal constant ERROR_HISTORY_UNCLEAR = "Drips history entry with hash and receivers";
+    bytes internal constant ERROR_HISTORY_UNCLEAR = "Entry with hash and receivers";
 
     // Keys are assetId and userId
     mapping(uint256 => mapping(uint256 => DripsReceiver[])) internal currReceiversStore;

--- a/test/Managed.t.sol
+++ b/test/Managed.t.sol
@@ -24,8 +24,8 @@ contract ManagedTest is Test {
     address internal pauser = address(2);
     address internal user = address(3);
 
-    bytes internal constant ERROR_NOT_ADMIN = "Caller is not the admin";
-    bytes internal constant ERROR_NOT_ADMIN_OR_PAUSER = "Caller is not the admin or a pauser";
+    bytes internal constant ERROR_NOT_ADMIN = "Caller not the admin";
+    bytes internal constant ERROR_NOT_ADMIN_OR_PAUSER = "Caller not the admin or a pauser";
 
     function setUp() public {
         logic = new Logic(0);

--- a/test/Splits.t.sol
+++ b/test/Splits.t.sol
@@ -5,6 +5,8 @@ import {Test} from "forge-std/Test.sol";
 import {Splits, SplitsReceiver} from "src/Splits.sol";
 
 contract SplitsTest is Test, Splits {
+    bytes internal constant ERROR_NOT_SORTED = "Splits receivers not sorted";
+
     // Keys is user ID
     mapping(uint256 => SplitsReceiver[]) internal currSplitsReceivers;
 
@@ -173,17 +175,11 @@ contract SplitsTest is Test, Splits {
     }
 
     function testRejectsUnsortedSplitsReceivers() public {
-        assertSetSplitsReverts(
-            user,
-            splitsReceivers(receiver2, 1, receiver1, 1),
-            "Splits receivers not sorted by user ID"
-        );
+        assertSetSplitsReverts(user, splitsReceivers(receiver2, 1, receiver1, 1), ERROR_NOT_SORTED);
     }
 
     function testRejectsDuplicateSplitsReceivers() public {
-        assertSetSplitsReverts(
-            user, splitsReceivers(receiver, 1, receiver, 2), "Duplicate splits receivers"
-        );
+        assertSetSplitsReverts(user, splitsReceivers(receiver, 1, receiver, 2), ERROR_NOT_SORTED);
     }
 
     function testCanSplitAllWhenCollectedDoesNotSplitEvenly() public {


### PR DESCRIPTION
The error messages now follow the 32-byte recommendation. Also removes a redundant require statement. It cuts the contract size by about 270 bytes allowing higher optimizer runs.