### PR TITLE
Use unchecked blocks where safe

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
 solc_version = '0.8.17'
-optimizer_runs = 7_000
+optimizer_runs = 11_900
 verbosity = 1
 fuzz_runs = 5
 [fmt]

--- a/src/DripsHub.sol
+++ b/src/DripsHub.sol
@@ -286,9 +286,7 @@ contract DripsHub is Managed, Drips, Splits {
     {
         uint256 assetId = _assetId(erc20);
         receivedAmt = Drips._receiveDrips(userId, assetId, maxCycles);
-        if (receivedAmt > 0) {
-            Splits._addSplittable(userId, assetId, receivedAmt);
-        }
+        if (receivedAmt > 0) Splits._addSplittable(userId, assetId, receivedAmt);
     }
 
     /// @notice Receive drips from the currently running cycle from a single sender.
@@ -320,9 +318,7 @@ contract DripsHub is Managed, Drips, Splits {
     ) public whenNotPaused returns (uint128 amt) {
         uint256 assetId = _assetId(erc20);
         amt = Drips._squeezeDrips(userId, assetId, senderId, historyHash, dripsHistory);
-        if (amt > 0) {
-            Splits._addSplittable(userId, assetId, amt);
-        }
+        if (amt > 0) Splits._addSplittable(userId, assetId, amt);
     }
 
     /// @notice Calculate effects of calling `squeezeDrips` with the given parameters.
@@ -662,9 +658,11 @@ contract DripsHub is Managed, Drips, Splits {
         whenNotPaused
         onlyDriver(userId)
     {
-        for (uint256 i = 0; i < userMetadata.length; i++) {
-            UserMetadata calldata metadata = userMetadata[i];
-            emit UserMetadataEmitted(userId, metadata.key, metadata.value);
+        unchecked {
+            for (uint256 i = 0; i < userMetadata.length; i++) {
+                UserMetadata calldata metadata = userMetadata[i];
+                emit UserMetadataEmitted(userId, metadata.key, metadata.value);
+            }
         }
     }
 

--- a/src/ImmutableSplitsDriver.sol
+++ b/src/ImmutableSplitsDriver.sol
@@ -61,8 +61,10 @@ contract ImmutableSplitsDriver is Managed {
         userId = nextUserId();
         StorageSlot.getUint256Slot(_counterSlot).value++;
         uint256 weightSum = 0;
-        for (uint256 i = 0; i < receivers.length; i++) {
-            weightSum += receivers[i].weight;
+        unchecked {
+            for (uint256 i = 0; i < receivers.length; i++) {
+                weightSum += receivers[i].weight;
+            }
         }
         require(weightSum == totalSplitsWeight, "Invalid total receivers weight");
         emit CreatedSplits(userId, dripsHub.hashSplits(receivers));


### PR DESCRIPTION
This saves quite some gas, depending on the function up to ~15%, and a lot of bytecode, now we're able to increase optimizer runs to almost 12K instead of going down to ~3.5K and still having to shave 30 bytes off. The code is designed and reviewed with making under- and over-flows impossible, so unchecked blocks don't introduce security concerns.