### PR TITLE
Add deployer contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,69 +84,28 @@ Set up environment variables configuring the deployed contracts:
 
 ```bash
 # OPTIONAL
-# Address of the governance of the deployed contracts. If not set, `ETH_FROM` is used.
-export GOVERNANCE="<ADDRESS>"
+# Address of the deployed contracts admin to set. If not set, the deployer's wallet address is used.
+export ADMIN="<ADDRESS>"
 
 # OPTIONAL
-# Address of Caller to use. If not set, a new instance is deployed.
-# If set to zero, newly deployed Caller-aware contracts don't get support for Caller.
-export CALLER="<ADDRESS>"
+# Cycle length  to use in `DRIPS_HUB_LOGIC` when it's deployed. If not set, 1 week is used.
+export DRIPS_HUB_CYCLE_SECS="<SECONDS>"
 
 # OPTIONAL
-# Address of DripsHub to use. If not set, a new instance is deployed.
-export DRIPS_HUB="<ADDRESS>"
-
-# OPTIONAL
-# Address of the DripsHub admin to set. If not set, `GOVERNANCE` is used.
+# Address of the DripsHub admin to set. If not set, `ADMIN` is used.
 export DRIPS_HUB_ADMIN="<ADDRESS>"
 
 # OPTIONAL
-# Address of the DripsHub logic contract to use in `DRIPS_HUB` when it's deployed.
-# If not set, a new instance is deployed.
-export DRIPS_HUB_LOGIC="<ADDRESS>"
-
-# OPTIONAL
-# Cycle length  to use in `DRIPS_HUB_LOGIC` when it's deployed. Default is 1 week.
-export CYCLE_SECS="<SECONDS>"
-
-# OPTIONAL
-# Address of AddressDriver to use. If not set, a new instance is deployed for `DRIPS_HUB`.
-export ADDRESS_DRIVER="<ADDRESS>"
-
-# OPTIONAL
-# Address of the AddressDriver admin to set. If not set, `GOVERNANCE` is used.
+# Address of the AddressDriver admin to set. If not set, `ADMIN` is used.
 export ADDRESS_DRIVER_ADMIN="<ADDRESS>"
 
 # OPTIONAL
-# Address of the AddressDriver logic contract to use in `ADDRESS_DRIVER` when it's deployed.
-# If not set, a new instance is deployed and a new app ID is registered for `ADDRESS_DRIVER`.
-export ADDRESS_DRIVER_LOGIC="<ADDRESS>"
-
-# OPTIONAL
-# Address of NFTDriver to use. If not set, a new instance is deployed for `DRIPS_HUB`.
-export NFT_DRIVER="<ADDRESS>"
-
-# OPTIONAL
-# Address of the NFTDriver admin to set. If not set, `GOVERNANCE` is used.
+# Address of the NFTDriver admin to set. If not set, `ADMIN` is used.
 export NFT_DRIVER_ADMIN="<ADDRESS>"
 
 # OPTIONAL
-# Address of the NFTDriver logic contract to use in `NFT_DRIVER` when it's deployed.
-# If not set, a new instance is deployed and a new app ID is registered for `NFT_DRIVER`.
-export NFT_DRIVER_LOGIC="<ADDRESS>"
-
-# OPTIONAL
-# Address of ImmutableSplitsDriver to use. If not set, a new instance is deployed for `DRIPS_HUB`.
-export SPLITS_DRIVER="<ADDRESS>"
-
-# OPTIONAL
-# Address of the ImmutableSplitsDriver admin to set. If not set, `GOVERNANCE` is used.
+# Address of the ImmutableSplitsDriver admin to set. If not set, `ADMIN` is used.
 export SPLITS_DRIVER_ADMIN="<ADDRESS>"
-
-# OPTIONAL
-# Address of the ImmutableSplitsDriver logic contract to use in `SPLITS_DRIVER` when it's deployed.
-# If not set, a new instance is deployed and a new app ID is registered for `SPLITS_DRIVER`.
-export SPLITS_DRIVER_LOGIC="<ADDRESS>"
 ```
 
 Run deployment:

--- a/src/Deployer.sol
+++ b/src/Deployer.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.17;
+
+import {AddressDriver} from "./AddressDriver.sol";
+import {Caller} from "./Caller.sol";
+import {DripsHub} from "./DripsHub.sol";
+import {Managed, ManagedProxy} from "./Managed.sol";
+import {NFTDriver} from "./NFTDriver.sol";
+import {ImmutableSplitsDriver} from "./ImmutableSplitsDriver.sol";
+
+contract Deployer {
+    // slither-disable-next-line immutable-states
+    address public creator;
+
+    DripsHub public dripsHub;
+    bytes public dripsHubArgs;
+    uint32 public dripsHubCycleSecs;
+    DripsHub public dripsHubLogic;
+    bytes public dripsHubLogicArgs;
+    address public dripsHubAdmin;
+
+    Caller public caller;
+    bytes public callerArgs;
+
+    AddressDriver public addressDriver;
+    bytes public addressDriverArgs;
+    AddressDriver public addressDriverLogic;
+    bytes public addressDriverLogicArgs;
+    address public addressDriverAdmin;
+    uint32 public addressDriverId;
+
+    NFTDriver public nftDriver;
+    bytes public nftDriverArgs;
+    NFTDriver public nftDriverLogic;
+    bytes public nftDriverLogicArgs;
+    address public nftDriverAdmin;
+    uint32 public nftDriverId;
+
+    ImmutableSplitsDriver public immutableSplitsDriver;
+    bytes public immutableSplitsDriverArgs;
+    ImmutableSplitsDriver public immutableSplitsDriverLogic;
+    bytes public immutableSplitsDriverLogicArgs;
+    address public immutableSplitsDriverAdmin;
+    uint32 public immutableSplitsDriverId;
+
+    constructor(
+        uint32 dripsHubCycleSecs_,
+        address dripsHubAdmin_,
+        address addressDriverAdmin_,
+        address nftDriverAdmin_,
+        address immutableSplitsDriverAdmin_
+    ) {
+        creator = msg.sender;
+        _deployDripsHub(dripsHubCycleSecs_, dripsHubAdmin_);
+        _deployCaller();
+        _deployAddressDriver(addressDriverAdmin_);
+        _deployNFTDriver(nftDriverAdmin_);
+        _deployImmutableSplitsDriver(immutableSplitsDriverAdmin_);
+    }
+
+    function _deployDripsHub(uint32 dripsHubCycleSecs_, address dripsHubAdmin_) internal {
+        // Deploy logic
+        dripsHubCycleSecs = dripsHubCycleSecs_;
+        dripsHubLogicArgs = abi.encode(dripsHubCycleSecs);
+        dripsHubLogic = new DripsHub(dripsHubCycleSecs);
+        // Deploy proxy
+        dripsHubAdmin = dripsHubAdmin_;
+        // slither-disable-next-line reentrancy-benign
+        ManagedProxy proxy = new ManagedProxy(dripsHubLogic, dripsHubAdmin);
+        dripsHub = DripsHub(address(proxy));
+        dripsHubArgs = abi.encode(dripsHubLogic, dripsHubAdmin);
+    }
+
+    function _deployCaller() internal {
+        caller = new Caller();
+        callerArgs = abi.encode();
+    }
+
+    /// @dev Requires DripsHub and Caller to be deployed
+    function _deployAddressDriver(address addressDriverAdmin_) internal {
+        // Deploy logic
+        address forwarder = address(caller);
+        uint32 driverId = dripsHub.nextDriverId();
+        addressDriverLogicArgs = abi.encode(dripsHub, forwarder, driverId);
+        addressDriverLogic = new AddressDriver(dripsHub, forwarder, driverId);
+        // Deploy proxy
+        addressDriverAdmin = addressDriverAdmin_;
+        // slither-disable-next-line reentrancy-benign
+        ManagedProxy proxy = new ManagedProxy(addressDriverLogic, addressDriverAdmin);
+        addressDriver = AddressDriver(address(proxy));
+        addressDriverArgs = abi.encode(addressDriverLogic, addressDriverAdmin);
+        // Register as a driver
+        addressDriverId = dripsHub.registerDriver(address(addressDriver));
+    }
+
+    /// @dev Requires DripsHub and Caller to be deployed
+    function _deployNFTDriver(address nftDriverAdmin_) internal {
+        // Deploy logic
+        address forwarder = address(caller);
+        uint32 driverId = dripsHub.nextDriverId();
+        nftDriverLogicArgs = abi.encode(dripsHub, forwarder, driverId);
+        nftDriverLogic = new NFTDriver(dripsHub, forwarder, driverId);
+        // Deploy proxy
+        nftDriverAdmin = nftDriverAdmin_;
+        // slither-disable-next-line reentrancy-benign
+        ManagedProxy proxy = new ManagedProxy(nftDriverLogic, nftDriverAdmin);
+        nftDriver = NFTDriver(address(proxy));
+        nftDriverArgs = abi.encode(nftDriverLogic, nftDriverAdmin);
+        // Register as a driver
+        nftDriverId = dripsHub.registerDriver(address(nftDriver));
+    }
+
+    /// @dev Requires DripsHub to be deployed
+    function _deployImmutableSplitsDriver(address immutableSplitsDriverAdmin_) internal {
+        // Deploy logic
+        uint32 driverId = dripsHub.nextDriverId();
+        immutableSplitsDriverLogicArgs = abi.encode(dripsHub, driverId);
+        immutableSplitsDriverLogic = new ImmutableSplitsDriver(dripsHub, driverId);
+        // Deploy proxy
+        immutableSplitsDriverAdmin = immutableSplitsDriverAdmin_;
+        // slither-disable-next-line reentrancy-benign
+        ManagedProxy proxy =
+            new ManagedProxy(immutableSplitsDriverLogic, immutableSplitsDriverAdmin);
+        immutableSplitsDriver = ImmutableSplitsDriver(address(proxy));
+        immutableSplitsDriverArgs =
+            abi.encode(immutableSplitsDriverLogic, immutableSplitsDriverAdmin);
+        // Register as a driver
+        immutableSplitsDriverId = dripsHub.registerDriver(address(immutableSplitsDriver));
+    }
+}

--- a/test/Deployer.t.sol
+++ b/test/Deployer.t.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {Address} from "openzeppelin-contracts/utils/Address.sol";
+import {ERC2771Context} from "openzeppelin-contracts/metatx/ERC2771Context.sol";
+import {
+    AddressDriver,
+    Caller,
+    Deployer,
+    Managed,
+    NFTDriver,
+    ImmutableSplitsDriver
+} from "src/Deployer.sol";
+import {DripsHub, SplitsReceiver, UserMetadata} from "src/DripsHub.sol";
+
+interface DriverMeta {
+    function dripsHub() external view returns (DripsHub);
+    function driverId() external view returns (uint32);
+}
+
+contract DeployerTest is Test {
+    function testDeployment() public {
+        // Deployment parameters
+        uint32 cycleSecs = 7 days;
+        address dripsHubAdmin = address(1);
+        address addressDriverAdmin = address(2);
+        address nftDriverAdmin = address(3);
+        address immutableSplitsDriverAdmin = address(4);
+
+        // Deployment
+        Deployer deployer = new Deployer(cycleSecs,
+            dripsHubAdmin,
+            addressDriverAdmin,
+            nftDriverAdmin,
+            immutableSplitsDriverAdmin);
+
+        // Deployed contracts
+        DripsHub dripsHub = deployer.dripsHub();
+        Caller caller = deployer.caller();
+        AddressDriver addressDriver = deployer.addressDriver();
+        NFTDriver nftDriver = deployer.nftDriver();
+        ImmutableSplitsDriver immutableSplitsDriver = deployer.immutableSplitsDriver();
+
+        // Check deployment addresses being deterministic
+        assertEq(deployer.creator(), address(this), "Invalid creator");
+        assertAddress(deployer, 1, address(dripsHub.implementation()));
+        assertAddress(deployer, 2, address(dripsHub));
+        assertAddress(deployer, 3, address(caller));
+        assertAddress(deployer, 4, address(addressDriver.implementation()));
+        assertAddress(deployer, 5, address(addressDriver));
+        assertAddress(deployer, 6, address(nftDriver.implementation()));
+        assertAddress(deployer, 7, address(nftDriver));
+        assertAddress(deployer, 8, address(immutableSplitsDriver.implementation()));
+        assertAddress(deployer, 9, address(immutableSplitsDriver));
+
+        // Check implementation addresses
+        assertImplementation(dripsHub, deployer.dripsHubLogic());
+        assertImplementation(addressDriver, deployer.addressDriverLogic());
+        assertImplementation(nftDriver, deployer.nftDriverLogic());
+        assertImplementation(immutableSplitsDriver, deployer.immutableSplitsDriverLogic());
+
+        // Check admins
+        assertAdmin(dripsHub, deployer.dripsHubAdmin(), dripsHubAdmin);
+        assertAdmin(addressDriver, deployer.addressDriverAdmin(), addressDriverAdmin);
+        assertAdmin(nftDriver, deployer.nftDriverAdmin(), nftDriverAdmin);
+        assertAdmin(
+            immutableSplitsDriver, deployer.immutableSplitsDriverAdmin(), immutableSplitsDriverAdmin
+        );
+
+        // Check DripsHub cycle length
+        assertEq(deployer.dripsHubCycleSecs(), cycleSecs, "Invalid deployer cycle length");
+        assertEq(dripsHub.cycleSecs(), cycleSecs, "Invalid cycle length");
+
+        // Check DripsHub being set
+        assertDripsHub(DriverMeta(address(addressDriver)), dripsHub);
+        assertDripsHub(DriverMeta(address(nftDriver)), dripsHub);
+        assertDripsHub(DriverMeta(address(immutableSplitsDriver)), dripsHub);
+
+        // Check Caller being a forwarder
+        assertForwarder(addressDriver, caller);
+        assertForwarder(nftDriver, caller);
+
+        // Check driver IDs registration
+        assertDriverId(0, DriverMeta(address(addressDriver)));
+        assertDriverId(1, DriverMeta(address(nftDriver)));
+        assertDriverId(2, DriverMeta(address(immutableSplitsDriver)));
+        assertEq(dripsHub.nextDriverId(), 3, "Invalid next driver ID");
+
+        // Implementations smoke test
+        UserMetadata[] memory metadata = new UserMetadata[](1);
+        metadata[0] = UserMetadata("key", "value");
+        addressDriver.emitUserMetadata(metadata);
+        nftDriver.mint(address(this), metadata);
+        SplitsReceiver[] memory receivers = new SplitsReceiver[](1);
+        receivers[0] = SplitsReceiver(123, immutableSplitsDriver.totalSplitsWeight());
+        immutableSplitsDriver.createSplits(receivers, metadata);
+    }
+
+    function assertAddress(Deployer deployer, uint256 nonce, address actual) internal {
+        address expected = computeCreateAddress(address(deployer), nonce);
+        assertEq(actual, expected, "Invalid deployment address");
+    }
+
+    function assertImplementation(Managed proxy, Managed logic) internal {
+        assertEq(address(proxy.implementation()), address(logic), "Invalid implementation address");
+    }
+
+    function assertAdmin(Managed proxy, address deployerAdmin, address expected) internal {
+        assertEq(proxy.admin(), expected, "Invalid admin");
+        assertEq(deployerAdmin, expected, "Invalid admin in deployer");
+    }
+
+    function assertDripsHub(DriverMeta driver, DripsHub dripsHub) internal {
+        assertEq(address(driver.dripsHub()), address(dripsHub), "Invalid DripsHub address");
+    }
+
+    function assertForwarder(ERC2771Context trusting, Caller caller) internal {
+        assertTrue(trusting.isTrustedForwarder(address(caller)), "Caller not a trusted forwarder");
+    }
+
+    function assertDriverId(uint32 driverId, DriverMeta driver) internal {
+        assertEq(driver.driverId(), driverId, "Invalid driver ID");
+        address registeredDriver = driver.dripsHub().driverAddress(driverId);
+        assertEq(registeredDriver, address(driver), "Invalid registered driver address");
+    }
+}


### PR DESCRIPTION
Makes deployment a single transaction. It requires less than 18M gas, which is fine even on chains with lower gas limits like Optimism (checked on its testnet, it works). Stores the deployment details on chain and updates the JSON. Makes deployment easily repeatable on different chains. Reduces the number of deployment options, now the entire set of contracts is always deployed. Adds tests for the deployment.