### PR TITLE
Add RepoDriver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "lib/chainlink"]
+	path = lib/chainlink
+	url = https://github.com/smartcontractkit/chainlink

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,4 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
 openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/
+chainlink/=lib/chainlink/contracts/src/v0.8/

--- a/src/NFTDriver.sol
+++ b/src/NFTDriver.sol
@@ -11,7 +11,6 @@ import {
 } from "./DripsHub.sol";
 import {Managed} from "./Managed.sol";
 import {Context, ERC2771Context} from "openzeppelin-contracts/metatx/ERC2771Context.sol";
-import {StorageSlot} from "openzeppelin-contracts/utils/StorageSlot.sol";
 import {
     ERC721,
     ERC721Burnable,

--- a/src/RepoDriver.sol
+++ b/src/RepoDriver.sol
@@ -1,0 +1,536 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.19;
+
+import {
+    DripsHub,
+    DripsReceiver,
+    IERC20,
+    SafeERC20,
+    SplitsReceiver,
+    UserMetadata
+} from "./DripsHub.sol";
+import {Managed} from "./Managed.sol";
+import {ERC677ReceiverInterface} from "chainlink/interfaces/ERC677ReceiverInterface.sol";
+import {LinkTokenInterface} from "chainlink/interfaces/LinkTokenInterface.sol";
+import {OperatorInterface} from "chainlink/interfaces/OperatorInterface.sol";
+import {BufferChainlink, CBORChainlink} from "chainlink/Chainlink.sol";
+import {Context, ERC2771Context} from "openzeppelin-contracts/metatx/ERC2771Context.sol";
+
+/// @notice The supported forges where repositories are stored.
+enum Forge {
+    GitHub,
+    GitLab
+}
+
+/// @notice A DripsHub driver implementing repository-based user identification.
+/// Each repository stored in one of the supported forges has a deterministic user ID assigned.
+/// By default the repositories have no owner and their users can't be controlled by anybody,
+/// use `requestUpdateOwner` to update the owner.
+contract RepoDriver is ERC677ReceiverInterface, ERC2771Context, Managed {
+    using SafeERC20 for IERC20;
+    using CBORChainlink for BufferChainlink.buffer;
+
+    uint256 internal constant CHAIN_ID_ETHEREUM = 1;
+    string internal constant CHAIN_NAME_ETHEREUM = "ethereum";
+    address internal constant LINK_TOKEN_ETHEREUM = 0x514910771AF9Ca656af840dff83E8264EcF986CA;
+
+    uint256 internal constant CHAIN_ID_GOERLI = 5;
+    string internal constant CHAIN_NAME_GOERLI = "goerli";
+    address internal constant LINK_TOKEN_GOERLI = 0x326C977E6efc84E512bB9C30f76E30c160eD06FB;
+
+    uint256 internal constant CHAIN_ID_SEPOLIA = 11155111;
+    string internal constant CHAIN_NAME_SEPOLIA = "sepolia";
+    address internal constant LINK_TOKEN_SEPOLIA = 0x779877A7B0D9E8603169DdbD7836e478b4624789;
+
+    /// @notice The DripsHub address used by this driver.
+    DripsHub public immutable dripsHub;
+    /// @notice The driver ID which this driver uses when calling DripsHub.
+    uint32 public immutable driverId;
+    /// @notice The Link token used for paying the operators.
+    LinkTokenInterface public immutable linkToken;
+
+    /// @notice The ERC-1967 storage slot holding a single `RepoDriverStorage` structure.
+    bytes32 private immutable _repoDriverStorageSlot = _erc1967Slot("eip1967.repoDriver.storage");
+    /// @notice The ERC-1967 storage slot holding a single `RepoDriverAnyApiStorage` structure.
+    bytes32 private immutable _repoDriverAnyApiStorageSlot =
+        _erc1967Slot("eip1967.repoDriver.anyApi.storage");
+
+    /// @notice Emitted when the AnyApi operator configuration is updated.
+    /// @param operator The new address of the AnyApi operator.
+    /// @param jobId The new AnyApi job ID used for requesting user owner updates.
+    /// @param defaultFee The new fee in Link for each user owner
+    /// update request when the driver is covering the cost.
+    event AnyApiOperatorUpdated(
+        OperatorInterface indexed operator, bytes32 indexed jobId, uint96 defaultFee
+    );
+
+    /// @notice Emitted when the user ownership update is requested.
+    /// @param userId The ID of the user.
+    /// @param forge The forge where the repository is stored.
+    /// @param name The name of the repository.
+    event OwnerUpdateRequested(uint256 indexed userId, Forge forge, bytes name);
+
+    /// @notice Emitted when the user ownership is updated.
+    /// @param userId The ID of the user.
+    /// @param owner The new owner of the repository.
+    event OwnerUpdated(uint256 indexed userId, address owner);
+
+    struct RepoDriverStorage {
+        /// @notice The owners of the users.
+        mapping(uint256 userId => address) userOwners;
+    }
+
+    struct RepoDriverAnyApiStorage {
+        /// @notice The requested user owner updates.
+        mapping(bytes32 requestId => uint256 userId) requestedUpdates;
+        /// @notice The new address of the AnyApi operator.
+        OperatorInterface operator;
+        /// @notice The fee in Link for each user owner
+        /// update request when the driver is covering the cost.
+        uint96 defaultFee;
+        /// @notice The AnyApi job ID used for requesting user owner updates.
+        bytes32 jobId;
+        /// @notice The AnyApi requests counter used as a nonce when calculating the request ID.
+        uint256 nonce;
+    }
+
+    /// @param _dripsHub The drips hub to use.
+    /// @param forwarder The ERC-2771 forwarder to trust. May be the zero address.
+    /// @param _driverId The driver ID to use when calling DripsHub.
+    constructor(DripsHub _dripsHub, address forwarder, uint32 _driverId)
+        ERC2771Context(forwarder)
+    {
+        dripsHub = _dripsHub;
+        driverId = _driverId;
+        // slither-disable-next-line uninitialized-local
+        address _linkToken;
+        if (block.chainid == CHAIN_ID_ETHEREUM) _linkToken = LINK_TOKEN_ETHEREUM;
+        else if (block.chainid == CHAIN_ID_GOERLI) _linkToken = LINK_TOKEN_GOERLI;
+        else if (block.chainid == CHAIN_ID_SEPOLIA) _linkToken = LINK_TOKEN_SEPOLIA;
+        else revert("Unsupported chain");
+        linkToken = LinkTokenInterface(_linkToken);
+    }
+
+    modifier onlyOwner(uint256 userId) {
+        require(_msgSender() == ownerOf(userId), "Caller is not the user owner");
+        _;
+    }
+
+    /// @notice Calculates the user ID.
+    /// Every user ID is a 256-bit integer constructed by concatenating:
+    /// `driverId (32 bits) | forgeId (8 bits) | nameEncoded (216 bits)`.
+    /// When `forge` is GitHub and `name` is at most 27 bytes long,
+    /// `forgeId` is 0 and `nameEncoded` is `name` right-padded with zeros
+    /// When `forge` is GitHub and `name` is longer than 27 bytes,
+    /// `forgeId` is 1 and `nameEncoded` is the lower 27 bytes of the hash of `name`.
+    /// When `forge` is GitLab and `name` is at most 27 bytes long,
+    /// `forgeId` is 2 and `nameEncoded` is `name` right-padded with zeros
+    /// When `forge` is GitLab and `name` is longer than 27 bytes,
+    /// `forgeId` is 3 and `nameEncoded` is the lower 27 bytes of the hash of `name`.
+    /// @param forge The forge where the repository is stored.
+    /// @param name The name of the repository.
+    /// For GitHub and GitLab it must follow the `user_name/repository_name` structure
+    /// and it must be formatted identically as in the repository's URL,
+    /// including the case of each letter and special characters being removed.
+    /// @return userId The user ID.
+    function calcUserId(Forge forge, bytes memory name) public view returns (uint256 userId) {
+        uint8 forgeId;
+        uint216 nameEncoded;
+        if (forge == Forge.GitHub) {
+            if (name.length <= 27) {
+                forgeId = 0;
+                nameEncoded = uint216(bytes27(name));
+            } else {
+                forgeId = 1;
+                // `nameEncoded` is the lower 27 bytes of the hash
+                nameEncoded = uint216(uint256(keccak256(name)));
+            }
+        } else {
+            if (name.length <= 27) {
+                forgeId = 2;
+                nameEncoded = uint216(bytes27(name));
+            } else {
+                forgeId = 3;
+                // `nameEncoded` is the lower 27 bytes of the hash
+                nameEncoded = uint216(uint256(keccak256(name)));
+            }
+        }
+        // By assignment we get `userId` value:
+        // `zeros (224 bits) | driverId (32 bits)`
+        userId = driverId;
+        // By bit shifting we get `userId` value:
+        // `zeros (216 bits) | driverId (32 bits) | zeros (8 bits)`
+        // By bit masking we get `userId` value:
+        // `zeros (216 bits) | driverId (32 bits) | forgeId (8 bits)`
+        userId = (userId << 8) | forgeId;
+        // By bit shifting we get `userId` value:
+        // `driverId (32 bits) | forgeId (8 bits) | zeros (216 bits)`
+        // By bit masking we get `userId` value:
+        // `driverId (32 bits) | forgeId (8 bits) | nameEncoded (216 bits)`
+        userId = (userId << 216) | nameEncoded;
+    }
+
+    /// @notice Updates the AnyApi operator configuration. Callable only by the admin.
+    /// @param operator The new address of the AnyApi operator.
+    /// @param jobId The new AnyApi job ID used for requesting user owner updates.
+    /// @param defaultFee The new fee in Link for each user owner
+    /// update request when the driver is covering the cost.
+    function updateAnyApiOperator(OperatorInterface operator, bytes32 jobId, uint96 defaultFee)
+        public
+        whenNotPaused
+        onlyAdmin
+    {
+        RepoDriverAnyApiStorage storage storageRef = _repoDriverAnyApiStorage();
+        storageRef.operator = operator;
+        storageRef.jobId = jobId;
+        storageRef.defaultFee = defaultFee;
+        emit AnyApiOperatorUpdated(operator, jobId, defaultFee);
+    }
+
+    /// @notice Gets the current AnyApi operator configuration.
+    /// @return operator The address of the AnyApi operator.
+    /// @return jobId The AnyApi job ID used for requesting user owner updates.
+    /// @return defaultFee The fee in Link for each user owner
+    /// update request when the driver is covering the cost.
+    function anyApiOperator()
+        public
+        view
+        returns (OperatorInterface operator, bytes32 jobId, uint96 defaultFee)
+    {
+        RepoDriverAnyApiStorage storage storageRef = _repoDriverAnyApiStorage();
+        operator = storageRef.operator;
+        jobId = storageRef.jobId;
+        defaultFee = storageRef.defaultFee;
+    }
+
+    /// @notice Gets the user owner.
+    /// @param userId The ID of the user.
+    /// @return owner The owner of the user.
+    function ownerOf(uint256 userId) public view returns (address owner) {
+        return _repoDriverStorage().userOwners[userId];
+    }
+
+    /// @notice Requests an update of the ownership of the user representing the repository.
+    /// The actual update of the owner will be made in a future transaction.
+    /// The driver will cover the fee in Link that must be paid to the operator.
+    /// If you want to cover the fee yourself, use `onTokenTransfer`.
+    ///
+    /// The repository must contain a `FUNDING.json` file in the project root in the default branch.
+    /// The file must be a valid JSON with arbitrary data, but it must contain the owner address
+    /// as a hexadecimal string under `drips` -> `<CHAIN NAME>` -> `ownedBy`, a minimal example:
+    /// `{ "drips": { "ethereum": { "ownedBy": "0x0123456789abcDEF0123456789abCDef01234567" } } }`.
+    /// If the operator can't read the owner when processing the update request,
+    /// it ignores the request and no change to the user ownership is made.
+    /// @param forge The forge where the repository is stored.
+    /// @param name The name of the repository.
+    /// For GitHub and GitLab it must follow the `user_name/repository_name` structure
+    /// and it must be formatted identically as in the repository's URL,
+    /// including the case of each letter and special characters being removed.
+    /// @return userId The ID of the user.
+    function requestUpdateOwner(Forge forge, bytes memory name)
+        public
+        whenNotPaused
+        returns (uint256 userId)
+    {
+        uint256 fee = _repoDriverAnyApiStorage().defaultFee;
+        require(linkToken.balanceOf(address(this)) >= fee, "Link balance too low");
+        return _requestUpdateOwner(forge, name, fee);
+    }
+
+    /// @notice The function called when receiving funds from ERC-677 `transferAndCall`.
+    /// Only supports receiving Link tokens, callable only by the Link token smart contract.
+    /// The only supported usage is requesting user ownership updates,
+    /// the transferred tokens are then used for paying the AnyApi operator fee,
+    /// see `requestUpdateOwner` for more details.
+    /// The received tokens are never refunded, so make sure that
+    /// the amount isn't too low to cover the fee, isn't too high and wasteful,
+    /// and the repository's content is valid so its ownership can be verified.
+    /// @param amount The transferred amount, it will be used as the AnyApi operator fee.
+    /// @param data The `transferAndCall` payload.
+    /// It must be a valid ABI-encoded calldata for `requestUpdateOwner`.
+    /// The call parameters will be used the same way as when calling `requestUpdateOwner`,
+    /// to determine which user's ownership update is requested.
+    function onTokenTransfer(address, /* sender */ uint256 amount, bytes calldata data)
+        public
+        whenNotPaused
+    {
+        require(msg.sender == address(linkToken), "Callable only by the Link token");
+        require(data.length >= 4, "Data not a valid calldata");
+        require(bytes4(data[:4]) == this.requestUpdateOwner.selector, "Data not requestUpdateOwner");
+        (Forge forge, bytes memory name) = abi.decode(data[4:], (Forge, bytes));
+        _requestUpdateOwner(forge, name, amount);
+    }
+
+    /// @notice Requests an update of the ownership of the user representing the repository.
+    /// See `requestUpdateOwner` for more details.
+    /// @param forge The forge where the repository is stored.
+    /// @param name The name of the repository.
+    /// @param fee The fee in Link to pay for the request.
+    /// @return userId The ID of the user.
+    function _requestUpdateOwner(Forge forge, bytes memory name, uint256 fee)
+        internal
+        returns (uint256 userId)
+    {
+        RepoDriverAnyApiStorage storage storageRef = _repoDriverAnyApiStorage();
+        address operator = address(storageRef.operator);
+        require(operator != address(0), "Operator address not set");
+        uint256 nonce = storageRef.nonce++;
+        bytes32 requestId = keccak256(abi.encodePacked(this, nonce));
+        userId = calcUserId(forge, name);
+        storageRef.requestedUpdates[requestId] = userId;
+        bytes memory payload = _requestPayload(forge, name);
+        bytes memory callData = abi.encodeCall(
+            OperatorInterface.operatorRequest,
+            (
+                address(0), // ignored, will be replaced in the operator with this contract's address
+                0, // ignored, will be replaced in the operator with the fee
+                storageRef.jobId,
+                this.updateOwnerByAnyApi.selector,
+                nonce,
+                2, // data version
+                payload
+            )
+        );
+        require(linkToken.transferAndCall(operator, fee, callData), "Transfer and call failed");
+        // slither-disable-next-line reentrancy-events
+        emit OwnerUpdateRequested(userId, forge, name);
+    }
+
+    /// @notice Builds the AnyApi generic `bytes` fetching request payload.
+    /// It instructs the operator to fetch the current owner of the user.
+    /// @param forge The forge where the repository is stored.
+    /// @param name The name of the repository.
+    /// @return payload The AnyApi request payload.
+    function _requestPayload(Forge forge, bytes memory name)
+        internal
+        view
+        returns (bytes memory payload)
+    {
+        // slither-disable-next-line uninitialized-local
+        BufferChainlink.buffer memory buffer;
+        buffer = BufferChainlink.init(buffer, 256);
+        buffer.encodeString("get");
+        buffer.encodeString(_requestUrl(forge, name));
+        buffer.encodeString("path");
+        buffer.encodeString(_requestPath());
+        return buffer.buf;
+    }
+
+    /// @notice Builds the URL for fetch the `FUNDING.json` file for the given repository.
+    /// @param forge The forge where the repository is stored.
+    /// @param name The name of the repository.
+    /// @return url The built URL.
+    function _requestUrl(Forge forge, bytes memory name)
+        internal
+        pure
+        returns (string memory url)
+    {
+        if (forge == Forge.GitHub) {
+            return string.concat(
+                "https://raw.githubusercontent.com/", string(name), "/HEAD/FUNDING.json"
+            );
+        } else if (forge == Forge.GitLab) {
+            return string.concat("https://gitlab.com/", string(name), "/-/raw/HEAD/FUNDING.json");
+        } else {
+            revert("Unsupported forge");
+        }
+    }
+
+    /// @notice Builds the JSON path inside `FUNDING.json` where the user ID owner is stored.
+    /// @return path The comma-separated JSON path.
+    function _requestPath() internal view returns (string memory path) {
+        // slither-disable-next-line uninitialized-local
+        string memory chainName;
+        if (block.chainid == CHAIN_ID_ETHEREUM) chainName = CHAIN_NAME_ETHEREUM;
+        else if (block.chainid == CHAIN_ID_GOERLI) chainName = CHAIN_NAME_GOERLI;
+        else if (block.chainid == CHAIN_ID_SEPOLIA) chainName = CHAIN_NAME_SEPOLIA;
+        else revert("Unsupported chain");
+        return string.concat("drips,", chainName, ",ownedBy");
+    }
+
+    /// @notice Updates the user owner. Callable only by the AnyApi operator.
+    /// @param requestId The ID of the AnyApi request.
+    /// Must be the same as the request ID generated when requesting an owner update,
+    /// this function will update the user ownership that was requested back then.
+    /// @param ownerRaw The new owner of the user. Must be a 20 bytes long address.
+    function updateOwnerByAnyApi(bytes32 requestId, bytes calldata ownerRaw) public whenNotPaused {
+        RepoDriverAnyApiStorage storage storageRef = _repoDriverAnyApiStorage();
+        require(msg.sender == address(storageRef.operator), "Callable only by the operator");
+        uint256 userId = storageRef.requestedUpdates[requestId];
+        require(userId != 0, "Unknown request ID");
+        delete storageRef.requestedUpdates[requestId];
+        require(ownerRaw.length == 20, "Invalid owner length");
+        address owner = address(bytes20(ownerRaw));
+        _repoDriverStorage().userOwners[userId] = owner;
+        emit OwnerUpdated(userId, owner);
+    }
+
+    /// @notice Collects the user's received already split funds
+    /// and transfers them out of the drips hub contract.
+    /// @param userId The ID of the collecting user. The caller must be the owner of the user.
+    /// @param erc20 The used ERC-20 token.
+    /// It must preserve amounts, so if some amount of tokens is transferred to
+    /// an address, then later the same amount must be transferable from that address.
+    /// Tokens which rebase the holders' balances, collect taxes on transfers,
+    /// or impose any restrictions on holding or transferring tokens are not supported.
+    /// If you use such tokens in the protocol, they can get stuck or lost.
+    /// @param transferTo The address to send collected funds to
+    /// @return amt The collected amount
+    function collect(uint256 userId, IERC20 erc20, address transferTo)
+        public
+        whenNotPaused
+        onlyOwner(userId)
+        returns (uint128 amt)
+    {
+        amt = dripsHub.collect(userId, erc20);
+        if (amt > 0) dripsHub.withdraw(erc20, transferTo, amt);
+    }
+
+    /// @notice Gives funds from the user to the receiver.
+    /// The receiver can split and collect them immediately.
+    /// Transfers the funds to be given from the message sender's wallet to the drips hub contract.
+    /// @param userId The ID of the giving user. The caller must be the owner of the user.
+    /// @param receiver The receiver
+    /// @param erc20 The used ERC-20 token.
+    /// It must preserve amounts, so if some amount of tokens is transferred to
+    /// an address, then later the same amount must be transferable from that address.
+    /// Tokens which rebase the holders' balances, collect taxes on transfers,
+    /// or impose any restrictions on holding or transferring tokens are not supported.
+    /// If you use such tokens in the protocol, they can get stuck or lost.
+    /// @param amt The given amount
+    function give(uint256 userId, uint256 receiver, IERC20 erc20, uint128 amt)
+        public
+        whenNotPaused
+        onlyOwner(userId)
+    {
+        if (amt > 0) _transferFromCaller(erc20, amt);
+        dripsHub.give(userId, receiver, erc20, amt);
+    }
+
+    /// @notice Sets the user's drips configuration.
+    /// Transfers funds between the message sender's wallet and the drips hub contract
+    /// to fulfil the change of the drips balance.
+    /// @param userId The ID of the configured user. The caller must be the owner of the user.
+    /// @param erc20 The used ERC-20 token.
+    /// It must preserve amounts, so if some amount of tokens is transferred to
+    /// an address, then later the same amount must be transferable from that address.
+    /// Tokens which rebase the holders' balances, collect taxes on transfers,
+    /// or impose any restrictions on holding or transferring tokens are not supported.
+    /// If you use such tokens in the protocol, they can get stuck or lost.
+    /// @param currReceivers The current drips receivers list.
+    /// It must be exactly the same as the last list set for the user with `setDrips`.
+    /// If this is the first update, pass an empty array.
+    /// @param balanceDelta The drips balance change to be applied.
+    /// Positive to add funds to the drips balance, negative to remove them.
+    /// @param newReceivers The list of the drips receivers of the sender to be set.
+    /// Must be sorted by the receivers' addresses, deduplicated and without 0 amtPerSecs.
+    /// @param maxEndHint1 An optional parameter allowing gas optimization, pass `0` to ignore it.
+    /// The first hint for finding the maximum end time when all drips stop due to funds
+    /// running out after the balance is updated and the new receivers list is applied.
+    /// Hints have no effect on the results of calling this function, except potentially saving gas.
+    /// Hints are Unix timestamps used as the starting points for binary search for the time
+    /// when funds run out in the range of timestamps from the current block's to `2^32`.
+    /// Hints lower than the current timestamp are ignored.
+    /// You can provide zero, one or two hints. The order of hints doesn't matter.
+    /// Hints are the most effective when one of them is lower than or equal to
+    /// the last timestamp when funds are still dripping, and the other one is strictly larger
+    /// than that timestamp,the smaller the difference between such hints, the higher gas savings.
+    /// The savings are the highest possible when one of the hints is equal to
+    /// the last timestamp when funds are still dripping, and the other one is larger by 1.
+    /// It's worth noting that the exact timestamp of the block in which this function is executed
+    /// may affect correctness of the hints, especially if they're precise.
+    /// Hints don't provide any benefits when balance is not enough to cover
+    /// a single second of dripping or is enough to cover all drips until timestamp `2^32`.
+    /// Even inaccurate hints can be useful, and providing a single hint
+    /// or two hints that don't enclose the time when funds run out can still save some gas.
+    /// Providing poor hints that don't reduce the number of binary search steps
+    /// may cause slightly higher gas usage than not providing any hints.
+    /// @param maxEndHint2 An optional parameter allowing gas optimization, pass `0` to ignore it.
+    /// The second hint for finding the maximum end time, see `maxEndHint1` docs for more details.
+    /// @param transferTo The address to send funds to in case of decreasing balance
+    /// @return realBalanceDelta The actually applied drips balance change.
+    function setDrips(
+        uint256 userId,
+        IERC20 erc20,
+        DripsReceiver[] calldata currReceivers,
+        int128 balanceDelta,
+        DripsReceiver[] calldata newReceivers,
+        // slither-disable-next-line similar-names
+        uint32 maxEndHint1,
+        uint32 maxEndHint2,
+        address transferTo
+    ) public whenNotPaused onlyOwner(userId) returns (int128 realBalanceDelta) {
+        if (balanceDelta > 0) _transferFromCaller(erc20, uint128(balanceDelta));
+        realBalanceDelta = dripsHub.setDrips(
+            userId, erc20, currReceivers, balanceDelta, newReceivers, maxEndHint1, maxEndHint2
+        );
+        if (realBalanceDelta < 0) dripsHub.withdraw(erc20, transferTo, uint128(-realBalanceDelta));
+    }
+
+    /// @notice Sets the user's splits configuration. The configuration is common for all assets.
+    /// Nothing happens to the currently splittable funds, but when they are split
+    /// after this function finishes, the new splits configuration will be used.
+    /// Because anybody can call `split` on `DripsHub`, calling this function may be frontrun
+    /// and all the currently splittable funds will be split using the old splits configuration.
+    /// @param userId The ID of the configured user. The caller must be the owner of the user.
+    /// @param receivers The list of the user's splits receivers to be set.
+    /// Must be sorted by the splits receivers' addresses, deduplicated and without 0 weights.
+    /// Each splits receiver will be getting `weight / TOTAL_SPLITS_WEIGHT`
+    /// share of the funds collected by the user.
+    /// If the sum of weights of all receivers is less than `_TOTAL_SPLITS_WEIGHT`,
+    /// some funds won't be split, but they will be left for the user to collect.
+    /// It's valid to include the user's own `userId` in the list of receivers,
+    /// but funds split to themselves return to their splittable balance and are not collectable.
+    /// This is usually unwanted, because if splitting is repeated,
+    /// funds split to themselves will be again split using the current configuration.
+    /// Splitting 100% to self effectively blocks splitting unless the configuration is updated.
+    function setSplits(uint256 userId, SplitsReceiver[] calldata receivers)
+        public
+        whenNotPaused
+        onlyOwner(userId)
+    {
+        dripsHub.setSplits(userId, receivers);
+    }
+
+    /// @notice Emits the user's metadata.
+    /// The keys and the values are not standardized by the protocol, it's up to the user
+    /// to establish and follow conventions to ensure compatibility with the consumers.
+    /// @param userId The ID of the emitting user. The caller must be the owner of the user.
+    /// @param userMetadata The list of user metadata.
+    function emitUserMetadata(uint256 userId, UserMetadata[] calldata userMetadata)
+        public
+        whenNotPaused
+        onlyOwner(userId)
+    {
+        if (userMetadata.length == 0) return;
+        dripsHub.emitUserMetadata(userId, userMetadata);
+    }
+
+    function _transferFromCaller(IERC20 erc20, uint128 amt) internal {
+        erc20.safeTransferFrom(_msgSender(), address(dripsHub), amt);
+    }
+
+    /// @notice Returns the RepoDriver storage.
+    /// @return storageRef The storage.
+    function _repoDriverStorage() internal view returns (RepoDriverStorage storage storageRef) {
+        bytes32 slot = _repoDriverStorageSlot;
+        // slither-disable-next-line assembly
+        assembly {
+            storageRef.slot := slot
+        }
+    }
+
+    /// @notice Returns the RepoDriver storage specific to AnyApi.
+    /// @return storageRef The storage.
+    function _repoDriverAnyApiStorage()
+        internal
+        view
+        returns (RepoDriverAnyApiStorage storage storageRef)
+    {
+        bytes32 slot = _repoDriverAnyApiStorageSlot;
+        // slither-disable-next-line assembly
+        assembly {
+            storageRef.slot := slot
+        }
+    }
+}

--- a/test/RepoDriver.t.sol
+++ b/test/RepoDriver.t.sol
@@ -1,0 +1,636 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.19;
+
+import {Caller} from "src/Caller.sol";
+import {Forge, RepoDriver} from "src/RepoDriver.sol";
+import {
+    DripsConfigImpl,
+    DripsHub,
+    DripsHistory,
+    DripsReceiver,
+    SplitsReceiver,
+    UserMetadata
+} from "src/DripsHub.sol";
+import {ManagedProxy} from "src/Managed.sol";
+import {BufferChainlink, CBORChainlink} from "chainlink/Chainlink.sol";
+import {ERC677ReceiverInterface} from "chainlink/interfaces/ERC677ReceiverInterface.sol";
+import {OperatorInterface} from "chainlink/interfaces/OperatorInterface.sol";
+import {LinkTokenInterface} from "chainlink/interfaces/LinkTokenInterface.sol";
+import {console2, Test} from "forge-std/Test.sol";
+import {
+    ERC20,
+    IERC20,
+    ERC20PresetFixedSupply
+} from "openzeppelin-contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+
+using CBORChainlink for BufferChainlink.buffer;
+
+contract TestLinkToken is ERC20("", "") {
+    function mint(address receiver, uint256 amount) public {
+        _mint(receiver, amount);
+    }
+
+    function transferAndCall(address to, uint256 value, bytes calldata data)
+        external
+        returns (bool success)
+    {
+        super.transfer(to, value);
+        ERC677ReceiverInterface(to).onTokenTransfer(msg.sender, value, data);
+        return true;
+    }
+}
+
+contract MockDummy {
+    fallback() external payable {
+        revert("Call not mocked");
+    }
+}
+
+contract RepoDriverTest is Test {
+    DripsHub internal dripsHub;
+    Caller internal caller;
+    RepoDriver internal driver;
+    uint256 internal driverNonce;
+    IERC20 internal erc20;
+
+    address internal admin = address(1);
+    address internal user = address(2);
+    uint256 internal userId;
+    uint256 internal userId1;
+    uint256 internal userId2;
+    uint256 internal userIdUser;
+
+    bytes internal constant ERROR_NOT_OWNER = "Caller is not the user owner";
+
+    uint256 internal constant CHAIN_ID_MAINNET = 1;
+    uint256 internal constant CHAIN_ID_GOERLI = 5;
+    uint256 internal constant CHAIN_ID_SEPOLIA = 11155111;
+
+    function setUp() public {
+        DripsHub hubLogic = new DripsHub(10);
+        dripsHub = DripsHub(address(new ManagedProxy(hubLogic, address(this))));
+
+        caller = new Caller();
+
+        // Make RepoDriver's driver ID non-0 to test if it's respected by RepoDriver
+        dripsHub.registerDriver(address(1));
+        dripsHub.registerDriver(address(1));
+        deployDriver(CHAIN_ID_MAINNET);
+
+        userId = initialUpdateOwner(address(this), "this/repo1");
+        userId1 = initialUpdateOwner(address(this), "this/repo2");
+        userId2 = initialUpdateOwner(address(this), "this/repo3");
+        userIdUser = initialUpdateOwner(user, "user/repo");
+
+        erc20 = new ERC20PresetFixedSupply("test", "test", type(uint136).max, address(this));
+        erc20.approve(address(driver), type(uint256).max);
+        erc20.transfer(user, erc20.totalSupply() / 100);
+        vm.prank(user);
+        erc20.approve(address(driver), type(uint256).max);
+    }
+
+    function deployDriver(uint256 chainId) public {
+        vm.chainId(chainId);
+        uint32 driverId = dripsHub.registerDriver(address(this));
+        RepoDriver driverLogic = new RepoDriver(dripsHub, address(caller), driverId);
+        driver = RepoDriver(address(new ManagedProxy(driverLogic, admin)));
+        dripsHub.updateDriverAddress(driverId, address(driver));
+        driverNonce = 0;
+        updateAnyApiOperator(OperatorInterface(address(new MockDummy())), keccak256("job ID"), 2);
+
+        TestLinkToken linkToken = TestLinkToken(address(driver.linkToken()));
+        vm.etch(address(linkToken), address(new TestLinkToken()).code);
+        linkToken.mint(address(this), 100);
+        linkToken.mint(address(driver), 100);
+    }
+
+    function noMetadata() internal pure returns (UserMetadata[] memory userMetadata) {
+        userMetadata = new UserMetadata[](0);
+    }
+
+    function someMetadata() internal pure returns (UserMetadata[] memory userMetadata) {
+        userMetadata = new UserMetadata[](1);
+        userMetadata[0] = UserMetadata("key", "value");
+    }
+
+    function updateAnyApiOperator(OperatorInterface operator, bytes32 jobId, uint96 defaultFee)
+        internal
+    {
+        vm.prank(admin);
+        driver.updateAnyApiOperator(operator, jobId, defaultFee);
+        (OperatorInterface newOperator, bytes32 newJobId, uint96 newDefaultFee) =
+            driver.anyApiOperator();
+        require(newOperator == operator, "Invalid operator after the update");
+        require(newJobId == jobId, "Invalid job ID after the update");
+        require(newDefaultFee == defaultFee, "Invalid default fee after the update");
+    }
+
+    function initialUpdateOwner(address owner, string memory name)
+        internal
+        returns (uint256 ownedUserId)
+    {
+        Forge forge = Forge.GitHub;
+        updateOwner(
+            forge,
+            bytes(name),
+            owner,
+            string.concat("https://raw.githubusercontent.com/", name, "/HEAD/FUNDING.json"),
+            "drips,ethereum,ownedBy"
+        );
+        return driver.calcUserId(forge, bytes(name));
+    }
+
+    function updateOwner(
+        Forge forge,
+        bytes memory name,
+        address owner,
+        string memory url,
+        string memory path
+    ) internal {
+        bytes32 requestId = requestUpdateOwner(forge, name, url, path);
+        updateOwnerByAnyApi(requestId, owner);
+        assertOwner(forge, name, owner);
+    }
+
+    function requestUpdateOwner(
+        Forge forge,
+        bytes memory name,
+        string memory url,
+        string memory path
+    ) internal returns (bytes32 requestId) {
+        (OperatorInterface operator,, uint96 fee) = driver.anyApiOperator();
+        LinkTokenInterface linkToken = driver.linkToken();
+        uint256 driverBalance = linkToken.balanceOf(address(driver));
+        uint256 operatorBalance = linkToken.balanceOf(address(operator));
+
+        mockOperatorRequest(url, path, driverNonce, fee);
+        driver.requestUpdateOwner(forge, name);
+        vm.clearMockedCalls();
+
+        assertEq(
+            linkToken.balanceOf(address(driver)), driverBalance - fee, "Invalid driver balance"
+        );
+        assertEq(
+            linkToken.balanceOf(address(operator)),
+            operatorBalance + fee,
+            "Invalid operator balance"
+        );
+        return calcRequestId(driverNonce++);
+    }
+
+    function mockOperatorRequest(string memory url, string memory path, uint256 nonce, uint256 fee)
+        internal
+    {
+        (OperatorInterface operator, bytes32 jobId,) = driver.anyApiOperator();
+
+        BufferChainlink.buffer memory buffer;
+        buffer = BufferChainlink.init(buffer, 256);
+        buffer.encodeString("get");
+        buffer.encodeString(url);
+        buffer.encodeString("path");
+        buffer.encodeString(path);
+
+        vm.mockCall(
+            address(operator),
+            abi.encodeCall(
+                ERC677ReceiverInterface.onTokenTransfer,
+                (
+                    address(driver),
+                    fee,
+                    abi.encodeCall(
+                        OperatorInterface.operatorRequest,
+                        (
+                            address(0),
+                            0,
+                            jobId,
+                            RepoDriver.updateOwnerByAnyApi.selector,
+                            nonce,
+                            2,
+                            buffer.buf
+                        )
+                        )
+                )
+            ),
+            ""
+        );
+    }
+
+    function updateOwnerByAnyApi(bytes32 requestId, address owner) internal {
+        (OperatorInterface operator,,) = driver.anyApiOperator();
+        vm.prank(address(operator));
+        driver.updateOwnerByAnyApi(requestId, abi.encodePacked(owner));
+    }
+
+    function assertOwner(Forge forge, bytes memory name, address expectedOwner) internal {
+        uint256 repoUserId = driver.calcUserId(forge, name);
+        assertEq(driver.ownerOf(repoUserId), expectedOwner, "Invalid user owner");
+    }
+
+    function calcRequestId(uint256 nonce) internal view returns (bytes32 requestId) {
+        return keccak256(abi.encodePacked(address(driver), nonce));
+    }
+
+    function testUserIdsDoNotCollideBetweenForges() public {
+        bytes memory name = "me/repo";
+        uint256 userIdGitHub = driver.calcUserId(Forge.GitHub, name);
+        uint256 userIdGitLab = driver.calcUserId(Forge.GitLab, name);
+        assertFalse(userIdGitHub == userIdGitLab, "User IDs collide");
+    }
+
+    function testCalcUserId() public {
+        bytes memory name3 = "a/b";
+        bytes memory name27 = "abcdefghijklm/nopqrstuvwxyz";
+        bytes memory name28 = "abcdefghijklm/nopqrstuvwxyz_";
+
+        // The lookup of the hex values for the manual inspection of the test
+        assertEq(driver.driverId(), 0x00000002, "Invalid driver ID hex representation");
+        assertEq(bytes3(name3), bytes3(0x612f62), "Invalid 3 byte name hex representation");
+        assertEq(
+            bytes27(name27),
+            bytes27(0x6162636465666768696a6b6c6d2f6e6f707172737475767778797a),
+            "Invalid 27 byte name hex representation"
+        );
+        assertEq(
+            keccak256(name28),
+            0x14ef39e0dc9b20b0f16f6d0e523b42684b6f3881fa3c23115048bc6643c2f866,
+            "Invalid 28 byte name hash"
+        );
+
+        assertUserId(
+            Forge.GitHub,
+            name3,
+            0x00000002_00_612f62000000000000000000000000000000000000000000000000
+        );
+        assertUserId(
+            Forge.GitHub,
+            name27,
+            0x00000002_00_6162636465666768696a6b6c6d2f6e6f707172737475767778797a
+        );
+        assertUserId(
+            Forge.GitHub,
+            name28,
+            0x00000002_01_9b20b0f16f6d0e523b42684b6f3881fa3c23115048bc6643c2f866
+        );
+        assertUserId(
+            Forge.GitLab,
+            name3,
+            0x00000002_02_612f62000000000000000000000000000000000000000000000000
+        );
+        assertUserId(
+            Forge.GitLab,
+            name27,
+            0x00000002_02_6162636465666768696a6b6c6d2f6e6f707172737475767778797a
+        );
+        assertUserId(
+            Forge.GitLab,
+            name28,
+            0x00000002_03_9b20b0f16f6d0e523b42684b6f3881fa3c23115048bc6643c2f866
+        );
+    }
+
+    function assertUserId(Forge forge, bytes memory name, uint256 expectedUserId) internal {
+        uint256 actualUserId = driver.calcUserId(forge, name);
+        assertEq(bytes32(actualUserId), bytes32(expectedUserId), "Invalid user ID");
+    }
+
+    function testDeploymentOnUnknownChainReverts() public {
+        vm.chainId(1234567890);
+        vm.expectRevert("Unsupported chain");
+        new RepoDriver(dripsHub, address(caller), 0);
+    }
+
+    function testUpdateOwnerGitHubMainnet() public {
+        updateOwner(
+            Forge.GitHub,
+            "me/repo",
+            user,
+            "https://raw.githubusercontent.com/me/repo/HEAD/FUNDING.json",
+            "drips,ethereum,ownedBy"
+        );
+    }
+
+    function testUpdateOwnerGitLabMainnet() public {
+        updateOwner(
+            Forge.GitLab,
+            "me/repo",
+            user,
+            "https://gitlab.com/me/repo/-/raw/HEAD/FUNDING.json",
+            "drips,ethereum,ownedBy"
+        );
+    }
+
+    function testUpdateOwnerGitHubGoerli() public {
+        deployDriver(CHAIN_ID_GOERLI);
+        updateOwner(
+            Forge.GitHub,
+            "me/repo",
+            user,
+            "https://raw.githubusercontent.com/me/repo/HEAD/FUNDING.json",
+            "drips,goerli,ownedBy"
+        );
+    }
+
+    function testUpdateOwnerGitHubSepolia() public {
+        deployDriver(CHAIN_ID_SEPOLIA);
+        updateOwner(
+            Forge.GitHub,
+            "me/repo",
+            user,
+            "https://raw.githubusercontent.com/me/repo/HEAD/FUNDING.json",
+            "drips,sepolia,ownedBy"
+        );
+    }
+
+    function testRequestUpdateOwnerRevertsWhenNotEnoughLink() public {
+        uint256 balance = driver.linkToken().balanceOf(address(driver));
+        (OperatorInterface operator, bytes32 jobId,) = driver.anyApiOperator();
+        updateAnyApiOperator(operator, jobId, uint96(balance) + 1);
+        vm.expectRevert("Link balance too low");
+        driver.requestUpdateOwner(Forge.GitHub, "me/repo");
+    }
+
+    function testRequestUpdateOwnerRevertsWhenOperatorAddressIsZero() public {
+        (, bytes32 jobId, uint96 fee) = driver.anyApiOperator();
+        updateAnyApiOperator(OperatorInterface(address(0)), jobId, fee);
+        vm.expectRevert("Operator address not set");
+        driver.requestUpdateOwner(Forge.GitHub, "me/repo");
+    }
+
+    function testUpdateOwnerByAnyApiRevertsIfNotCalledByTheOperator() public {
+        bytes32 requestId = requestUpdateOwner(
+            Forge.GitHub,
+            "me/repo",
+            "https://raw.githubusercontent.com/me/repo/HEAD/FUNDING.json",
+            "drips,ethereum,ownedBy"
+        );
+        vm.expectRevert("Callable only by the operator");
+        driver.updateOwnerByAnyApi(requestId, abi.encodePacked(user));
+    }
+
+    function testUpdateOwnerByAnyApiRevertsIfUnknownRequestId() public {
+        (OperatorInterface operator,,) = driver.anyApiOperator();
+        vm.prank(address(operator));
+        vm.expectRevert("Unknown request ID");
+        driver.updateOwnerByAnyApi(keccak256("requestId"), abi.encodePacked(user));
+    }
+
+    function testUpdateOwnerByAnyApiRevertsIfReusedRequestId() public {
+        bytes32 requestId = requestUpdateOwner(
+            Forge.GitHub,
+            "me/repo",
+            "https://raw.githubusercontent.com/me/repo/HEAD/FUNDING.json",
+            "drips,ethereum,ownedBy"
+        );
+        (OperatorInterface operator,,) = driver.anyApiOperator();
+
+        vm.prank(address(operator));
+        driver.updateOwnerByAnyApi(requestId, abi.encodePacked(user));
+
+        vm.prank(address(operator));
+        vm.expectRevert("Unknown request ID");
+        driver.updateOwnerByAnyApi(requestId, abi.encodePacked(user));
+    }
+
+    function testUpdateOwnerByAnyApiRevertsIfOwnerIsNotAddress() public {
+        bytes32 requestId = requestUpdateOwner(
+            Forge.GitHub,
+            "me/repo",
+            "https://raw.githubusercontent.com/me/repo/HEAD/FUNDING.json",
+            "drips,ethereum,ownedBy"
+        );
+        (OperatorInterface operator,,) = driver.anyApiOperator();
+
+        vm.prank(address(operator));
+        vm.expectRevert("Invalid owner length");
+        driver.updateOwnerByAnyApi(requestId, abi.encodePacked(user, uint8(0)));
+    }
+
+    function testOnTokenTransfer() public {
+        (OperatorInterface operator,,) = driver.anyApiOperator();
+        LinkTokenInterface linkToken = driver.linkToken();
+        uint256 thisBalance = linkToken.balanceOf(address(this));
+        uint256 operatorBalance = linkToken.balanceOf(address(operator));
+        uint256 fee = thisBalance / 2;
+
+        mockOperatorRequest(
+            "https://raw.githubusercontent.com/me/repo/HEAD/FUNDING.json",
+            "drips,ethereum,ownedBy",
+            driverNonce,
+            fee
+        );
+        linkToken.transferAndCall(
+            address(driver),
+            fee,
+            abi.encodeCall(driver.requestUpdateOwner, (Forge.GitHub, "me/repo"))
+        );
+
+        assertEq(linkToken.balanceOf(address(this)), thisBalance - fee, "Invalid this balance");
+        assertEq(
+            linkToken.balanceOf(address(operator)),
+            operatorBalance + fee,
+            "Invalid operator balance"
+        );
+        updateOwnerByAnyApi(calcRequestId(driverNonce), user);
+    }
+
+    function testOnTokenTransferRevertsIfNotLinkIsReceived() public {
+        TestLinkToken notLinkToken = new TestLinkToken();
+        notLinkToken.mint(address(this), 1);
+        vm.expectRevert("Callable only by the Link token");
+        notLinkToken.transferAndCall(
+            address(driver), 1, abi.encodeCall(driver.requestUpdateOwner, (Forge.GitHub, "me/repo"))
+        );
+    }
+
+    function testOnTokenTransferRevertsIfPayloadIsNotCalldata() public {
+        LinkTokenInterface linkToken = driver.linkToken();
+        vm.expectRevert("Data not a valid calldata");
+        linkToken.transferAndCall(address(driver), 1, "abc");
+    }
+
+    function testOnTokenTransferRevertsIfPayloadHasInvalidSelector() public {
+        LinkTokenInterface linkToken = driver.linkToken();
+        vm.expectRevert("Data not requestUpdateOwner");
+        linkToken.transferAndCall(
+            address(driver),
+            1,
+            abi.encodeWithSelector(driver.updateOwnerByAnyApi.selector, Forge.GitHub, "me/repo")
+        );
+    }
+
+    function testOnTokenTransferRevertsIfPayloadIsNotValidCalldata() public {
+        LinkTokenInterface linkToken = driver.linkToken();
+        vm.expectRevert(bytes(""));
+        linkToken.transferAndCall(
+            address(driver),
+            1,
+            abi.encodeWithSelector(driver.requestUpdateOwner.selector, "me/repo")
+        );
+    }
+
+    function testCollect() public {
+        uint128 amt = 5;
+        driver.give(userId1, userId2, erc20, amt);
+        dripsHub.split(userId2, erc20, new SplitsReceiver[](0));
+        uint256 balance = erc20.balanceOf(address(this));
+        uint128 collected = driver.collect(userId2, erc20, address(this));
+        assertEq(collected, amt, "Invalid collected");
+        assertEq(erc20.balanceOf(address(this)), balance + amt, "Invalid balance");
+        assertEq(erc20.balanceOf(address(dripsHub)), 0, "Invalid DripsHub balance");
+    }
+
+    function testCollectTransfersFundsToTheProvidedAddress() public {
+        uint128 amt = 5;
+        driver.give(userId1, userId2, erc20, amt);
+        dripsHub.split(userId2, erc20, new SplitsReceiver[](0));
+        address transferTo = address(1234);
+        uint128 collected = driver.collect(userId2, erc20, transferTo);
+        assertEq(collected, amt, "Invalid collected");
+        assertEq(erc20.balanceOf(transferTo), amt, "Invalid balance");
+        assertEq(erc20.balanceOf(address(dripsHub)), 0, "Invalid DripsHub balance");
+    }
+
+    function testCollectRevertsWhenNotUserOwner() public {
+        vm.expectRevert(ERROR_NOT_OWNER);
+        driver.collect(userIdUser, erc20, address(this));
+    }
+
+    function testGive() public {
+        uint128 amt = 5;
+        uint256 balance = erc20.balanceOf(address(this));
+        driver.give(userId1, userId2, erc20, amt);
+        assertEq(erc20.balanceOf(address(this)), balance - amt, "Invalid balance");
+        assertEq(erc20.balanceOf(address(dripsHub)), amt, "Invalid DripsHub balance");
+        assertEq(dripsHub.splittable(userId2, erc20), amt, "Invalid received amount");
+    }
+
+    function testGiveRevertsWhenNotUserOwner() public {
+        vm.expectRevert(ERROR_NOT_OWNER);
+        driver.give(userIdUser, userId, erc20, 5);
+    }
+
+    function testSetDrips() public {
+        uint128 amt = 5;
+        // Top-up
+        DripsReceiver[] memory receivers = new DripsReceiver[](1);
+        receivers[0] =
+            DripsReceiver(userId2, DripsConfigImpl.create(0, dripsHub.minAmtPerSec(), 0, 0));
+        uint256 balance = erc20.balanceOf(address(this));
+        int128 realBalanceDelta = driver.setDrips(
+            userId1, erc20, new DripsReceiver[](0), int128(amt), receivers, 0, 0, address(this)
+        );
+        assertEq(erc20.balanceOf(address(this)), balance - amt, "Invalid balance after top-up");
+        assertEq(erc20.balanceOf(address(dripsHub)), amt, "Invalid DripsHub balance after top-up");
+        (,,, uint128 dripsBalance,) = dripsHub.dripsState(userId1, erc20);
+        assertEq(dripsBalance, amt, "Invalid drips balance after top-up");
+        assertEq(realBalanceDelta, int128(amt), "Invalid drips balance delta after top-up");
+        (bytes32 dripsHash,,,,) = dripsHub.dripsState(userId1, erc20);
+        assertEq(dripsHash, dripsHub.hashDrips(receivers), "Invalid drips hash after top-up");
+        // Withdraw
+        balance = erc20.balanceOf(address(user));
+        realBalanceDelta =
+            driver.setDrips(userId1, erc20, receivers, -int128(amt), receivers, 0, 0, address(user));
+        assertEq(erc20.balanceOf(address(user)), balance + amt, "Invalid balance after withdrawal");
+        assertEq(erc20.balanceOf(address(dripsHub)), 0, "Invalid DripsHub balance after withdrawal");
+        (,,, dripsBalance,) = dripsHub.dripsState(userId1, erc20);
+        assertEq(dripsBalance, 0, "Invalid drips balance after withdrawal");
+        assertEq(realBalanceDelta, -int128(amt), "Invalid drips balance delta after withdrawal");
+    }
+
+    function testSetDripsDecreasingBalanceTransfersFundsToTheProvidedAddress() public {
+        uint128 amt = 5;
+        DripsReceiver[] memory receivers = new DripsReceiver[](0);
+        driver.setDrips(userId, erc20, receivers, int128(amt), receivers, 0, 0, address(this));
+        address transferTo = address(1234);
+        int128 realBalanceDelta =
+            driver.setDrips(userId, erc20, receivers, -int128(amt), receivers, 0, 0, transferTo);
+        assertEq(erc20.balanceOf(transferTo), amt, "Invalid balance");
+        assertEq(erc20.balanceOf(address(dripsHub)), 0, "Invalid DripsHub balance");
+        (,,, uint128 dripsBalance,) = dripsHub.dripsState(userId1, erc20);
+        assertEq(dripsBalance, 0, "Invalid drips balance");
+        assertEq(realBalanceDelta, -int128(amt), "Invalid drips balance delta");
+    }
+
+    function testSetDripsRevertsWhenNotUserOwner() public {
+        DripsReceiver[] memory noReceivers = new DripsReceiver[](0);
+        vm.expectRevert(ERROR_NOT_OWNER);
+        driver.setDrips(userIdUser, erc20, noReceivers, 0, noReceivers, 0, 0, address(this));
+    }
+
+    function testSetSplits() public {
+        SplitsReceiver[] memory receivers = new SplitsReceiver[](1);
+        receivers[0] = SplitsReceiver(userId2, 1);
+        driver.setSplits(userId, receivers);
+        bytes32 actual = dripsHub.splitsHash(userId);
+        bytes32 expected = dripsHub.hashSplits(receivers);
+        assertEq(actual, expected, "Invalid splits hash");
+    }
+
+    function testSetSplitsRevertsWhenNotUserOwner() public {
+        vm.expectRevert(ERROR_NOT_OWNER);
+        driver.setSplits(userIdUser, new SplitsReceiver[](0));
+    }
+
+    function testEmitUserMetadata() public {
+        driver.emitUserMetadata(userId, someMetadata());
+    }
+
+    function testEmitUserMetadataRevertsWhenNotUserOwner() public {
+        vm.expectRevert(ERROR_NOT_OWNER);
+        driver.emitUserMetadata(userIdUser, someMetadata());
+    }
+
+    function testForwarderIsTrusted() public {
+        vm.prank(user);
+        caller.authorize(address(this));
+        assertEq(dripsHub.splittable(userId, erc20), 0, "Invalid splittable before give");
+        uint128 amt = 10;
+        bytes memory giveData =
+            abi.encodeWithSelector(driver.give.selector, userIdUser, userId, erc20, amt);
+        caller.callAs(user, address(driver), giveData);
+        assertEq(dripsHub.splittable(userId, erc20), amt, "Invalid splittable after give");
+    }
+
+    modifier canBePausedTest() {
+        vm.prank(admin);
+        driver.pause();
+        vm.expectRevert("Contract paused");
+        _;
+    }
+
+    function testUpdateAnyApiOperatorCanBePaused() public canBePausedTest {
+        driver.updateAnyApiOperator(OperatorInterface(address(0)), 0, 0);
+    }
+
+    function testRequestUpdateOwnerCanBePaused() public canBePausedTest {
+        driver.requestUpdateOwner(Forge.GitHub, "");
+    }
+
+    function testOnTokenTransferCanBePaused() public canBePausedTest {
+        driver.onTokenTransfer(address(0), 0, "");
+    }
+
+    function testUpdateOwnerByAnyApiCanBePaused() public canBePausedTest {
+        driver.updateOwnerByAnyApi(0, "");
+    }
+
+    function testCollectCanBePaused() public canBePausedTest {
+        driver.collect(0, erc20, user);
+    }
+
+    function testGiveCanBePaused() public canBePausedTest {
+        driver.give(0, 0, erc20, 0);
+    }
+
+    function testSetDripsCanBePaused() public canBePausedTest {
+        driver.setDrips(0, erc20, new DripsReceiver[](0), 0, new DripsReceiver[](0), 0, 0, user);
+    }
+
+    function testSetSplitsCanBePaused() public canBePausedTest {
+        driver.setSplits(0, new SplitsReceiver[](0));
+    }
+
+    function testEmitUserMetadataCanBePaused() public canBePausedTest {
+        driver.emitUserMetadata(0, noMetadata());
+    }
+}


### PR DESCRIPTION
The production logic is ready to be merged, there are no tests yet, working on them.

Tested out on Goerli (0x45Aa599e4EB38300025eAB83908652bcC61601D4) with GitHub and GitLab, both with the driver covering the fees and the user with `transferAndCall`. 
